### PR TITLE
feat: multi-tenant custom domain with SSL provisioning and SUPER_ADMIN config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,16 @@ pipeline {
         AUTH_DATABASE_URL    = credentials('fazri-auth-database-url')
         BETTER_AUTH_SECRET   = credentials('fazri-better-auth-secret')
         AUTH_TRUSTED_ORIGINS = credentials('fazri-auth-trusted-origins')
+        AUTH_COOKIE_DOMAIN   = credentials('fazri-cookie-domain')
+
+        // ── NPM (Nginx Proxy Manager) ─────────────────────────────────────────
+        NPM_API_URL          = credentials('fazri-npm-api-url')
+        NPM_EMAIL            = credentials('fazri-npm-email')
+        NPM_PASSWORD         = credentials('fazri-npm-password')
+
+        // ── Multi-tenant domain routing ───────────────────────────────────────
+        FAZRI_BASE_DOMAIN    = credentials('fazri-base-domain')
+        FAZRI_SERVER_IP      = credentials('fazri-server-ip')
 
         // ── Notification credentials ──────────────────────────────────────────
         DISCORD_WEBHOOK_URL  = credentials('fazri-discord-webhook-url')
@@ -358,6 +368,12 @@ pipeline {
                                 -e BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET}" \
                                 -e TRUSTED_ORIGINS="${AUTH_TRUSTED_ORIGINS}" \
                                 -e AUTH_SERVICE_URL="${AUTH_SERVICE_URL}" \
+                                -e COOKIE_DOMAIN="${AUTH_COOKIE_DOMAIN}" \
+                                -e NPM_API_URL="${NPM_API_URL}" \
+                                -e NPM_EMAIL="${NPM_EMAIL}" \
+                                -e NPM_PASSWORD="${NPM_PASSWORD}" \
+                                -e FAZRI_BASE_DOMAIN="${FAZRI_BASE_DOMAIN}" \
+                                -e FAZRI_SERVER_IP="${FAZRI_SERVER_IP}" \
                                 -e NODE_ENV=production \
                                 -e PORT=4000 \
                                 -e SENTRY_DSN="${AUTH_SENTRY_DSN}" \

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -38,7 +38,8 @@ RUN PRISMA_PKG=$(ls -d /app/node_modules/.pnpm/@prisma+client@* | head -1) && \
 
 # pnpm deploy copies workspace package source but not compiled dist/.
 # Copy @fazri/npm-sdk dist explicitly so the runner can resolve it.
-RUN cp -r /app/packages/npm-sdk/dist /deploy/node_modules/@fazri/npm-sdk/dist
+RUN mkdir -p /deploy/node_modules/@fazri/npm-sdk && \
+    cp -rL /app/packages/npm-sdk/dist /deploy/node_modules/@fazri/npm-sdk/dist
 
 FROM node:22-alpine AS runner
 WORKDIR /app

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -36,6 +36,10 @@ RUN PRISMA_PKG=$(ls -d /app/node_modules/.pnpm/@prisma+client@* | head -1) && \
     DEPLOY_PKG="/deploy/node_modules/.pnpm/$(basename "$PRISMA_PKG")" && \
     cp -r "$PRISMA_PKG/node_modules/.prisma" "$DEPLOY_PKG/node_modules/.prisma"
 
+# pnpm deploy copies workspace package source but not compiled dist/.
+# Copy @fazri/npm-sdk dist explicitly so the runner can resolve it.
+RUN cp -r /app/packages/npm-sdk/dist /deploy/node_modules/@fazri/npm-sdk/dist
+
 FROM node:22-alpine AS runner
 WORKDIR /app
 

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -7,6 +7,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY patches/ ./patches/
 COPY apps/auth/package.json ./apps/auth/
 COPY packages/db/package.json ./packages/db/
+COPY packages/npm-sdk/package.json ./packages/npm-sdk/
 
 # Install all workspace dependencies
 RUN pnpm install --frozen-lockfile
@@ -14,9 +15,13 @@ RUN pnpm install --frozen-lockfile
 # Copy source files
 COPY apps/auth/ ./apps/auth/
 COPY packages/db/ ./packages/db/
+COPY packages/npm-sdk/ ./packages/npm-sdk/
 
 # Build @fazri/db (prisma generate + tsc → dist/)
 RUN pnpm --filter=@fazri/db build
+
+# Build @fazri/npm-sdk (tsc → dist/)
+RUN pnpm --filter=@fazri/npm-sdk build
 
 # Build auth (tsc → dist/)
 RUN pnpm --filter=@fazri/auth build

--- a/apps/auth/env.example
+++ b/apps/auth/env.example
@@ -3,6 +3,10 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/ethos_iitg"
 AUTH_SERVICE_URL=http://localhost:4000
 PORT=4000
 
+# ─── Multi-tenant domain routing ─────────────────────────────────────────────
+FAZRI_BASE_DOMAIN=yourdomain.com
+FAZRI_SERVER_IP=                 # Public IP of this server — used for A record DNS verification
+
 #CORS
 TRUSTED_ORIGINS=http://localhost:3000,https://domain.com
 

--- a/apps/auth/env.example
+++ b/apps/auth/env.example
@@ -1,16 +1,23 @@
 BETTER_AUTH_SECRET=change-me-to-a-random-32-char-string
 DATABASE_URL="postgresql://postgres:password@localhost:5432/ethos_iitg"
 AUTH_SERVICE_URL=http://localhost:4000
+COOKIE_DOMAIN=.yourdomain.com       # Must start with a dot — scopes the auth cookie across all subdomains
 PORT=4000
 
 # ─── Multi-tenant domain routing ─────────────────────────────────────────────
-FAZRI_BASE_DOMAIN=yourdomain.com
-FAZRI_SERVER_IP=                 # Public IP of this server — used for A record DNS verification
+FAZRI_BASE_DOMAIN=yourdomain.com    # Root domain — org subdomains are resolved as slug.yourdomain.com
+FAZRI_SERVER_IP=                    # Public IP of this server — required for A record DNS verification before SSL provisioning
 
 #CORS
 TRUSTED_ORIGINS=http://localhost:3000,https://domain.com
 
-# Sentry
+# ─── Nginx Proxy Manager ─────────────────────────────────────────────────────
+NPM_API_URL=                        # Base URL of the NPM admin API, e.g. http://10.0.0.1:81
+NPM_EMAIL=                          # NPM login email (used if NPM_API_TOKEN is not set)
+NPM_PASSWORD=                       # NPM login password (used if NPM_API_TOKEN is not set)
+NPM_API_TOKEN=                      # Optional — takes priority over email/password if set
+
+# ─── Sentry ──────────────────────────────────────────────────────────────────
 SENTRY_ENABLED=false
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=development

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -9,14 +9,15 @@
   },
   "dependencies": {
     "@better-auth/sso": "1.5.4",
-    "samlify": "~2.10.2",
     "@fazri/db": "workspace:*",
     "@sentry/node": "^8",
     "bcryptjs": "^2.4.3",
     "better-auth": "1.5.4",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "@fazri/npm-sdk": "workspace:*",
+    "samlify": "~2.10.2"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -3,13 +3,15 @@ import * as Sentry from "@sentry/node";
 import express from "express";
 import cors from "cors";
 import { promises as dns, setServers as dnsSetServers } from "dns";
-
-dnsSetServers(["1.1.1.1", "1.0.0.1"]);
 import net from "net";
 import { toNodeHandler } from "better-auth/node";
 import { auth, refreshSSOProviderIds } from "./auth";
 import { prisma } from "@fazri/db";
 import { provisionCustomDomain, reprovisionCustomDomain, deprovisionCustomDomain, syncNpmSettings, createNpmClient, type NpmProvisionConfig } from "./npm-provision";
+
+// Process-global DNS override — affects all dns.resolve* calls but NOT dns.lookup / libuv getaddrinfo.
+// Forces Cloudflare resolvers to avoid split-horizon or ISP caching issues.
+dnsSetServers(["1.1.1.1", "1.0.0.1"]);
 
 async function getSystemSetting(key: string, fallback: string): Promise<string> {
   const row = await prisma.systemSetting.findUnique({ where: { key } });
@@ -215,7 +217,7 @@ app.get("/api/org/resolve", async (req, res) => {
       }
       const org = await prisma.organization.findUnique({ where: { slug } });
       if (!org) { res.status(404).json({ error: "Organization not found" }); return; }
-      res.json({ organizationId: org.id, slug: org.slug, name: org.name });
+      res.json({ organizationId: org.id, slug: org.slug });
       return;
     }
 
@@ -227,7 +229,6 @@ app.get("/api/org/resolve", async (req, res) => {
     res.json({
       organizationId: orgDomain.organizationId,
       slug: orgDomain.organization.slug,
-      name: orgDomain.organization.name,
     });
   } catch (err) {
     console.error("org-resolve error:", err);
@@ -639,7 +640,7 @@ app.post("/api/domain/:id/sync-npm", async (req, res) => {
     }
     syncNpmLastCalled.set(record.id, Date.now());
 
-    const result = await syncNpmSettings(record.domain);
+    const result = await syncNpmSettings(record.domain, record.npmProxyHostId);
     res.json({ success: true, hostId: result.id });
   } catch (err) {
     console.error("domain-sync-npm error:", err);

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -200,8 +200,9 @@ app.delete("/api/sso-providers/:providerId", async (req, res) => {
 // ─── Org resolution (used by Next.js middleware — no auth required) ──────────
 
 app.get("/api/org/resolve", async (req, res) => {
-  const hostname = (req.query.hostname as string) ?? "";
-  if (!hostname) {
+  const raw = req.query.hostname;
+  const hostname = (Array.isArray(raw) ? raw[0] : raw) ?? "";
+  if (!hostname || typeof hostname !== "string") {
     res.status(400).json({ error: "hostname required" });
     return;
   }
@@ -496,7 +497,7 @@ app.post("/api/domain/activate", async (req, res) => {
         });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        console.error(`[domain-activate] SSL provisioning failed for ${domain}:`, msg);
+        console.error("[domain-activate] SSL provisioning failed for domain:", domain, msg);
         await prisma.organizationDomain.update({
           where: { domain },
           data: { sslStatus: "failed", sslError: msg },

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -2,9 +2,36 @@ import "./instrument";
 import * as Sentry from "@sentry/node";
 import express from "express";
 import cors from "cors";
+import { promises as dns, setServers as dnsSetServers } from "dns";
+
+dnsSetServers(["1.1.1.1", "1.0.0.1"]);
+import net from "net";
 import { toNodeHandler } from "better-auth/node";
 import { auth, refreshSSOProviderIds } from "./auth";
 import { prisma } from "@fazri/db";
+import { provisionCustomDomain, reprovisionCustomDomain, deprovisionCustomDomain, syncNpmSettings } from "./npm-provision";
+
+// Cloudflare published IPv4 CIDRs — used to detect domains behind CF proxy
+const CLOUDFLARE_CIDRS = [
+  "103.21.244.0/22", "103.22.200.0/22", "103.31.4.0/22",
+  "104.16.0.0/13", "104.24.0.0/14", "108.162.192.0/18",
+  "131.0.72.0/22", "141.101.64.0/18", "162.158.0.0/15",
+  "172.64.0.0/13", "173.245.48.0/20", "188.114.96.0/20",
+  "190.93.240.0/20", "197.234.240.0/22", "198.41.128.0/17",
+];
+
+function ipInCidr(ip: string, cidr: string): boolean {
+  const [range, bits] = cidr.split("/");
+  const mask = ~(2 ** (32 - parseInt(bits, 10)) - 1) >>> 0;
+  const ipInt = ip.split(".").reduce((acc, oct) => (acc << 8) + parseInt(oct, 10), 0) >>> 0;
+  const rangeInt = range.split(".").reduce((acc, oct) => (acc << 8) + parseInt(oct, 10), 0) >>> 0;
+  return (ipInt & mask) === (rangeInt & mask);
+}
+
+function isCloudflareIp(ip: string): boolean {
+  if (!net.isIPv4(ip)) return false;
+  return CLOUDFLARE_CIDRS.some((cidr) => ipInCidr(ip, cidr));
+}
 
 const app = express();
 const PORT = parseInt(process.env.PORT ?? "4000", 10);
@@ -155,6 +182,487 @@ app.delete("/api/sso-providers/:providerId", async (req, res) => {
   }
 });
 
+// ─── Org resolution (used by Next.js middleware — no auth required) ──────────
+
+app.get("/api/org/resolve", async (req, res) => {
+  const hostname = (req.query.hostname as string) ?? "";
+  if (!hostname) {
+    res.status(400).json({ error: "hostname required" });
+    return;
+  }
+
+  try {
+    const baseDomain = process.env.FAZRI_BASE_DOMAIN ?? "rayzrsole.com";
+
+    if (hostname.endsWith(`.${baseDomain}`)) {
+      const slug = hostname.slice(0, -(`.${baseDomain}`.length));
+      if (!slug || slug.includes(".")) {
+        res.status(404).json({ error: "Not found" });
+        return;
+      }
+      const org = await prisma.organization.findUnique({ where: { slug } });
+      if (!org) { res.status(404).json({ error: "Organization not found" }); return; }
+      res.json({ organizationId: org.id, slug: org.slug, name: org.name });
+      return;
+    }
+
+    const orgDomain = await prisma.organizationDomain.findUnique({
+      where: { domain: hostname, verified: true },
+      include: { organization: true },
+    });
+    if (!orgDomain) { res.status(404).json({ error: "Domain not registered" }); return; }
+    res.json({
+      organizationId: orgDomain.organizationId,
+      slug: orgDomain.organization.slug,
+      name: orgDomain.organization.name,
+    });
+  } catch (err) {
+    console.error("org-resolve error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// ─── Custom domain management ─────────────────────────────────────────────────
+
+async function assertOrgAccess(session: NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>, organizationId: string): Promise<boolean> {
+  if ((session.user as Record<string, unknown>).role === "SUPER_ADMIN") return true;
+  const membership = await prisma.member.findFirst({
+    where: { userId: session.user.id, organizationId, role: { in: ["owner", "admin"] } },
+  });
+  return !!membership;
+}
+
+app.post("/api/domain/register", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session) { res.status(401).json({ error: "Unauthorized" }); return; }
+
+    const { organizationId, domain } = req.body as { organizationId: string; domain: string };
+    if (!organizationId || !domain) {
+      res.status(400).json({ error: "organizationId and domain required" });
+      return;
+    }
+
+    const hasAccess = await assertOrgAccess(session, organizationId);
+    if (!hasAccess) { res.status(403).json({ error: "Forbidden" }); return; }
+
+    const existing = await prisma.organizationDomain.findUnique({ where: { domain } });
+    if (existing) {
+      res.status(409).json({ error: "Domain already registered" });
+      return;
+    }
+
+    const record = await prisma.organizationDomain.create({
+      data: { organizationId, domain },
+    });
+
+    res.json({
+      id: record.id,
+      domain: record.domain,
+      verificationToken: record.verificationToken,
+      ownershipVerified: record.ownershipVerified,
+      verified: record.verified,
+      // Only TXT record shown at registration — CNAME is shown after ownership is verified
+      txtRecord: {
+        name: `_fazri-verify.${domain}`,
+        value: `fazri-verify=${record.verificationToken}`,
+      },
+    });
+  } catch (err) {
+    console.error("domain-register error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// Step 1 — verify domain ownership via TXT record
+app.post("/api/domain/verify", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session) { res.status(401).json({ error: "Unauthorized" }); return; }
+
+    const { domain } = req.body as { domain: string };
+    if (!domain) { res.status(400).json({ error: "domain required" }); return; }
+
+    const record = await prisma.organizationDomain.findUnique({ where: { domain } });
+    if (!record) { res.status(404).json({ error: "Domain not registered" }); return; }
+
+    const hasAccess = await assertOrgAccess(session, record.organizationId);
+    if (!hasAccess) { res.status(403).json({ error: "Forbidden" }); return; }
+
+    if (record.ownershipVerified) {
+      const cnameTarget = `app.${process.env.FAZRI_BASE_DOMAIN ?? "rayzrsole.com"}`;
+      res.json({ ownershipVerified: true, message: "Ownership already verified", cnameRecord: { name: domain.split(".")[0], value: cnameTarget } });
+      return;
+    }
+
+    const txtName = `_fazri-verify.${domain}`;
+    const expectedValue = `fazri-verify=${record.verificationToken}`;
+    let passed = false;
+
+    try {
+      const records = await dns.resolveTxt(txtName);
+      passed = records.some((r) => r.join("") === expectedValue);
+    } catch {
+      // DNS lookup failed
+    }
+
+    if (!passed) {
+      res.status(422).json({
+        ownershipVerified: false,
+        error: "TXT record not found or incorrect",
+        expected: { name: txtName, value: expectedValue },
+      });
+      return;
+    }
+
+    await prisma.organizationDomain.update({
+      where: { domain },
+      data: { ownershipVerified: true, ownershipVerifiedAt: new Date() },
+    });
+
+    const cnameTarget = `app.${process.env.FAZRI_BASE_DOMAIN ?? "rayzrsole.com"}`;
+    res.json({
+      ownershipVerified: true,
+      message: "Ownership verified — now point your domain",
+      cnameRecord: {
+        name: domain.split(".")[0],
+        value: cnameTarget,
+      },
+    });
+  } catch (err) {
+    console.error("domain-verify error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// DNS check — verifies A record resolves to this server (polled by frontend before Activate)
+const dnsCheckLastCalled = new Map<string, number>();
+const DNS_CHECK_COOLDOWN_MS = 10_000;
+
+app.get("/api/domain/check-dns", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session) { res.status(401).json({ error: "Unauthorized" }); return; }
+
+    const domain = req.query.domain as string;
+    if (!domain) { res.status(400).json({ error: "domain query param required" }); return; }
+
+    const record = await prisma.organizationDomain.findUnique({ where: { domain } });
+    if (!record) { res.status(404).json({ error: "Domain not registered" }); return; }
+
+    const hasAccess = await assertOrgAccess(session, record.organizationId);
+    if (!hasAccess) { res.status(403).json({ error: "Forbidden" }); return; }
+
+    const last = dnsCheckLastCalled.get(domain) ?? 0;
+    if (Date.now() - last < DNS_CHECK_COOLDOWN_MS) {
+      res.status(429).json({ error: "Checked too recently — wait a moment" });
+      return;
+    }
+    dnsCheckLastCalled.set(domain, Date.now());
+
+    const serverIp = process.env.FAZRI_SERVER_IP ?? "";
+    if (!serverIp) {
+      res.json({ status: "config-error", resolvedIps: [], expectedIp: "" });
+      return;
+    }
+
+    let resolvedIps: string[] = [];
+    try {
+      resolvedIps = await dns.resolve4(domain);
+    } catch {
+      res.json({ status: "not-propagated", resolvedIps: [], expectedIp: serverIp });
+      return;
+    }
+
+    if (resolvedIps.some(isCloudflareIp)) {
+      res.json({
+        status: "cloudflare-proxy",
+        resolvedIps,
+        expectedIp: serverIp,
+        warning: "Domain is behind Cloudflare proxy. Disable the orange cloud for this record — HTTP-01 certificate challenge requires direct reachability.",
+      });
+      return;
+    }
+
+    if (resolvedIps.includes(serverIp)) {
+      res.json({ status: "ok", resolvedIps, expectedIp: serverIp });
+    } else {
+      res.json({ status: "wrong-ip", resolvedIps, expectedIp: serverIp });
+    }
+  } catch (err) {
+    console.error("domain-check-dns error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// Step 2 — activate: check CNAME reachability + provision SSL via NPM
+app.post("/api/domain/activate", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session) { res.status(401).json({ error: "Unauthorized" }); return; }
+
+    const { domain } = req.body as { domain: string };
+    if (!domain) { res.status(400).json({ error: "domain required" }); return; }
+
+    const record = await prisma.organizationDomain.findUnique({
+      where: { domain },
+      include: { organization: true },
+    });
+    if (!record) { res.status(404).json({ error: "Domain not registered" }); return; }
+
+    const hasAccess = await assertOrgAccess(session, record.organizationId);
+    if (!hasAccess) { res.status(403).json({ error: "Forbidden" }); return; }
+
+    if (!record.ownershipVerified) {
+      res.status(422).json({ error: "Complete ownership verification before activating" });
+      return;
+    }
+
+    if (record.verified) {
+      res.json({ verified: true, message: "Domain already active" });
+      return;
+    }
+
+    // DNS pre-check — hard gate, not optional
+    const serverIp = process.env.FAZRI_SERVER_IP ?? "";
+    if (!serverIp && process.env.NPM_API_URL) {
+      res.status(500).json({
+        error: "FAZRI_SERVER_IP is not set on the auth service. Add your server's public IP to the auth env and restart.",
+      });
+      return;
+    }
+    if (serverIp) {
+      let addrs: string[];
+      try {
+        addrs = await dns.resolve4(domain);
+      } catch {
+        res.status(422).json({ error: "A record not found — add the DNS record and wait for propagation before activating" });
+        return;
+      }
+      if (addrs.some(isCloudflareIp)) {
+        res.status(422).json({
+          error: "Domain is behind Cloudflare proxy (orange cloud). Disable proxy mode for this A record — Let's Encrypt HTTP-01 requires direct reachability.",
+        });
+        return;
+      }
+      if (!addrs.includes(serverIp)) {
+        res.status(422).json({
+          error: `A record not pointing to this server — resolved ${addrs.join(", ")}, expected ${serverIp}`,
+        });
+        return;
+      }
+    }
+
+    // Atomic update — only proceeds if still not verified (guards concurrent requests)
+    const { count } = await prisma.organizationDomain.updateMany({
+      where: { domain, verified: false },
+      data: { verified: true, verifiedAt: new Date(), sslStatus: "provisioning", sslProvisioningStartedAt: new Date() },
+    });
+    if (count === 0) {
+      res.json({ verified: true, message: "Domain already active" });
+      return;
+    }
+
+    // Tracked async — updates sslStatus in DB on both success and failure
+    void (async () => {
+      try {
+        const { hostId } = await provisionCustomDomain(domain, record.organization.name);
+        await prisma.organizationDomain.update({
+          where: { domain },
+          data: { sslStatus: "active", npmProxyHostId: hostId, sslError: null },
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[domain-activate] SSL provisioning failed for ${domain}:`, msg);
+        await prisma.organizationDomain.update({
+          where: { domain },
+          data: { sslStatus: "failed", sslError: msg },
+        }).catch(console.error);
+      }
+    })();
+
+    res.json({ verified: true, message: "Domain activated — SSL certificate provisioning started" });
+  } catch (err) {
+    console.error("domain-activate error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+app.get("/api/domain/:organizationId", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session) { res.status(401).json({ error: "Unauthorized" }); return; }
+
+    const { organizationId } = req.params;
+    const hasAccess = await assertOrgAccess(session, organizationId);
+    if (!hasAccess) { res.status(403).json({ error: "Forbidden" }); return; }
+
+    const domains = await prisma.organizationDomain.findMany({
+      where: { organizationId },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true, domain: true, ownershipVerified: true, ownershipVerifiedAt: true,
+        verified: true, verifiedAt: true, verificationToken: true, createdAt: true,
+        sslStatus: true, sslProvisioningStartedAt: true, sslError: true, npmProxyHostId: true,
+      },
+    });
+
+    // Heal stale provisioning: if stuck >20 min, mark as failed
+    const staleThreshold = new Date(Date.now() - 20 * 60 * 1000);
+    const stale = domains.filter(
+      (d) => d.sslStatus === "provisioning" && d.sslProvisioningStartedAt && d.sslProvisioningStartedAt < staleThreshold
+    );
+    if (stale.length > 0) {
+      await Promise.all(
+        stale.map((d) =>
+          prisma.organizationDomain.update({
+            where: { id: d.id },
+            data: { sslStatus: "failed", sslError: "Provisioning timed out (service may have restarted)" },
+          })
+        )
+      );
+      for (const d of stale) {
+        d.sslStatus = "failed";
+        d.sslError = "Provisioning timed out (service may have restarted)";
+      }
+    }
+
+    res.json(domains);
+  } catch (err) {
+    console.error("domain-list error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+app.post("/api/domain/:id/retry-ssl", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session) { res.status(401).json({ error: "Unauthorized" }); return; }
+
+    const record = await prisma.organizationDomain.findUnique({
+      where: { id: req.params.id },
+      include: { organization: true },
+    });
+    if (!record) { res.status(404).json({ error: "Not found" }); return; }
+    if (!record.verified || record.sslStatus !== "failed") {
+      res.status(422).json({ error: "Domain must be active with a failed SSL status to retry" });
+      return;
+    }
+
+    const hasAccess = await assertOrgAccess(session, record.organizationId);
+    if (!hasAccess) { res.status(403).json({ error: "Forbidden" }); return; }
+
+    if (record.sslError && /too many certificates|rateLimited/i.test(record.sslError)) {
+      res.status(429).json({ rateLimited: true, error: "Let's Encrypt rate limited (5 certs/domain/week). Wait before retrying." });
+      return;
+    }
+
+    await prisma.organizationDomain.update({
+      where: { id: record.id },
+      data: { sslStatus: "provisioning", sslProvisioningStartedAt: new Date(), sslError: null },
+    });
+
+    res.status(202).json({ message: "SSL retry started" });
+
+    // Tracked async provisioning
+    void (async () => {
+      try {
+        const { hostId } = await reprovisionCustomDomain(record.domain, record.organization.name, record.npmProxyHostId);
+        await prisma.organizationDomain.update({
+          where: { id: record.id },
+          data: { sslStatus: "active", npmProxyHostId: hostId, sslError: null },
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[retry-ssl] Re-provisioning failed for ${record.domain}:`, msg);
+        await prisma.organizationDomain.update({
+          where: { id: record.id },
+          data: { sslStatus: "failed", sslError: msg },
+        }).catch(console.error);
+      }
+    })();
+  } catch (err) {
+    console.error("domain-retry-ssl error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+const syncNpmLastCalled = new Map<string, number>();
+const SYNC_NPM_COOLDOWN_MS = 60_000;
+
+app.post("/api/domain/:id/sync-npm", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session) { res.status(401).json({ error: "Unauthorized" }); return; }
+
+    const record = await prisma.organizationDomain.findUnique({ where: { id: req.params.id } });
+    if (!record) { res.status(404).json({ error: "Not found" }); return; }
+    if (!record.verified) { res.status(422).json({ error: "Domain is not active yet" }); return; }
+
+    const hasAccess = await assertOrgAccess(session, record.organizationId);
+    if (!hasAccess) { res.status(403).json({ error: "Forbidden" }); return; }
+
+    const lastCalled = syncNpmLastCalled.get(record.id) ?? 0;
+    const secondsLeft = Math.ceil((SYNC_NPM_COOLDOWN_MS - (Date.now() - lastCalled)) / 1000);
+    if (secondsLeft > 0) {
+      res.status(429).json({ error: "Already synced recently - try again shortly" });
+      return;
+    }
+    syncNpmLastCalled.set(record.id, Date.now());
+
+    const result = await syncNpmSettings(record.domain);
+    res.json({ success: true, hostId: result.id });
+  } catch (err) {
+    console.error("domain-sync-npm error:", err);
+    const msg = err instanceof Error ? err.message : "Internal server error";
+    res.status(500).json({ error: msg });
+  }
+});
+
+app.delete("/api/domain/:id", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session) { res.status(401).json({ error: "Unauthorized" }); return; }
+
+    const record = await prisma.organizationDomain.findUnique({ where: { id: req.params.id } });
+    if (!record) { res.status(404).json({ error: "Not found" }); return; }
+
+    const hasAccess = await assertOrgAccess(session, record.organizationId);
+    if (!hasAccess) { res.status(403).json({ error: "Forbidden" }); return; }
+
+    const domainName = record.domain;
+    const proxyHostId = record.npmProxyHostId;
+    await prisma.organizationDomain.delete({ where: { id: req.params.id } });
+    res.json({ success: true });
+
+    // Clean up NPM proxy host by ID after responding — targeted delete avoids racing a re-register
+    if (proxyHostId) {
+      deprovisionCustomDomain(domainName, proxyHostId).catch((err) =>
+        console.error(`[domain-delete] NPM cleanup failed for ${domainName}:`, err)
+      );
+    }
+  } catch (err) {
+    console.error("domain-delete error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 app.post("/api/check-username", async (req, res) => {
   const { username } = req.body as { username: string };
   if (!username || typeof username !== "string") {
@@ -178,4 +686,10 @@ Sentry.setupExpressErrorHandler(app);
 
 app.listen(PORT, () => {
   console.log(`Auth service running on port ${PORT}`);
-}); 
+  if (!process.env.NPM_API_URL) {
+    console.warn("[startup] NPM_API_URL not set — SSL auto-provisioning disabled. Domains will be marked active without certificate setup.");
+  }
+  if (process.env.NPM_API_URL && !process.env.FAZRI_SERVER_IP) {
+    console.warn("[startup] NPM_API_URL is set but FAZRI_SERVER_IP is missing — DNS verification will be skipped and domain activation will be blocked. Set FAZRI_SERVER_IP to your server's public IP.");
+  }
+});

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -9,7 +9,20 @@ import net from "net";
 import { toNodeHandler } from "better-auth/node";
 import { auth, refreshSSOProviderIds } from "./auth";
 import { prisma } from "@fazri/db";
-import { provisionCustomDomain, reprovisionCustomDomain, deprovisionCustomDomain, syncNpmSettings } from "./npm-provision";
+import { provisionCustomDomain, reprovisionCustomDomain, deprovisionCustomDomain, syncNpmSettings, createNpmClient, type NpmProvisionConfig } from "./npm-provision";
+
+async function getSystemSetting(key: string, fallback: string): Promise<string> {
+  const row = await prisma.systemSetting.findUnique({ where: { key } });
+  return row?.value ?? process.env[key] ?? fallback;
+}
+
+async function getNpmProvisionConfig(): Promise<NpmProvisionConfig> {
+  const [frontendHost, frontendPortStr] = await Promise.all([
+    getSystemSetting("FRONTEND_HOST", process.env.FRONTEND_HOST ?? "frontend"),
+    getSystemSetting("FRONTEND_PORT", process.env.FRONTEND_PORT ?? "3000"),
+  ]);
+  return { frontendHost, frontendPort: parseInt(frontendPortStr, 10) };
+}
 
 // Cloudflare published IPv4 CIDRs — used to detect domains behind CF proxy
 const CLOUDFLARE_CIDRS = [
@@ -474,7 +487,8 @@ app.post("/api/domain/activate", async (req, res) => {
     // Tracked async — updates sslStatus in DB on both success and failure
     void (async () => {
       try {
-        const { hostId } = await provisionCustomDomain(domain, record.organization.name);
+        const npmCfg = await getNpmProvisionConfig();
+        const { hostId } = await provisionCustomDomain(domain, record.organization.name, npmCfg);
         await prisma.organizationDomain.update({
           where: { domain },
           data: { sslStatus: "active", npmProxyHostId: hostId, sslError: null },
@@ -579,7 +593,8 @@ app.post("/api/domain/:id/retry-ssl", async (req, res) => {
     // Tracked async provisioning
     void (async () => {
       try {
-        const { hostId } = await reprovisionCustomDomain(record.domain, record.organization.name, record.npmProxyHostId);
+        const npmCfg = await getNpmProvisionConfig();
+        const { hostId } = await reprovisionCustomDomain(record.domain, record.organization.name, record.npmProxyHostId, npmCfg);
         await prisma.organizationDomain.update({
           where: { id: record.id },
           data: { sslStatus: "active", npmProxyHostId: hostId, sslError: null },
@@ -659,6 +674,146 @@ app.delete("/api/domain/:id", async (req, res) => {
     }
   } catch (err) {
     console.error("domain-delete error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// ─── System settings (SUPER_ADMIN only) ──────────────────────────────────────
+
+app.get("/api/system/npm-config", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session || (session.user as Record<string, unknown>).role !== "SUPER_ADMIN") {
+      res.status(403).json({ error: "Forbidden" });
+      return;
+    }
+
+    const [hostRow, portRow] = await Promise.all([
+      prisma.systemSetting.findUnique({ where: { key: "FRONTEND_HOST" } }),
+      prisma.systemSetting.findUnique({ where: { key: "FRONTEND_PORT" } }),
+    ]);
+
+    res.json({
+      frontendHost: hostRow?.value ?? process.env.FRONTEND_HOST ?? "frontend",
+      frontendPort: parseInt(portRow?.value ?? process.env.FRONTEND_PORT ?? "3000", 10),
+      updatedAt: hostRow?.updatedAt ?? portRow?.updatedAt ?? null,
+    });
+  } catch (err) {
+    console.error("system/npm-config GET error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+app.put("/api/system/npm-config", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session || (session.user as Record<string, unknown>).role !== "SUPER_ADMIN") {
+      res.status(403).json({ error: "Forbidden" });
+      return;
+    }
+
+    const { frontendHost, frontendPort } = req.body as { frontendHost: string; frontendPort: number };
+    if (!frontendHost || typeof frontendHost !== "string" || !frontendHost.trim()) {
+      res.status(400).json({ error: "frontendHost must be a non-empty string" });
+      return;
+    }
+    const port = Number(frontendPort);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      res.status(400).json({ error: "frontendPort must be an integer between 1 and 65535" });
+      return;
+    }
+
+    await Promise.all([
+      prisma.systemSetting.upsert({
+        where: { key: "FRONTEND_HOST" },
+        create: { key: "FRONTEND_HOST", value: frontendHost.trim() },
+        update: { value: frontendHost.trim() },
+      }),
+      prisma.systemSetting.upsert({
+        where: { key: "FRONTEND_PORT" },
+        create: { key: "FRONTEND_PORT", value: String(port) },
+        update: { value: String(port) },
+      }),
+    ]);
+
+    res.json({ frontendHost: frontendHost.trim(), frontendPort: port });
+  } catch (err) {
+    console.error("system/npm-config PUT error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+app.post("/api/system/npm-config/sync", async (req, res) => {
+  try {
+    const session = await auth.api.getSession({
+      headers: new Headers({ cookie: req.headers.cookie ?? "" }),
+    });
+    if (!session || (session.user as Record<string, unknown>).role !== "SUPER_ADMIN") {
+      res.status(403).json({ error: "Forbidden" });
+      return;
+    }
+
+    if (!process.env.NPM_API_URL) {
+      res.status(422).json({ error: "NPM_API_URL is not configured — cannot sync proxy hosts" });
+      return;
+    }
+
+    const cfg = await getNpmProvisionConfig();
+    const [verifiedDomains, allNpmHosts] = await Promise.all([
+      prisma.organizationDomain.findMany({
+        where: { verified: true },
+        select: { id: true, domain: true, npmProxyHostId: true },
+      }),
+      createNpmClient().proxyHosts.list(),
+    ]);
+
+    // Build a domain→npmHostId lookup from the live NPM list
+    const npmHostByDomain = new Map<string, number>();
+    for (const h of allNpmHosts) {
+      for (const d of h.domain_names) {
+        npmHostByDomain.set(d, h.id);
+      }
+    }
+
+    const synced: string[] = [];
+    const failed: { domain: string; error: string }[] = [];
+    const client = createNpmClient();
+
+    await Promise.allSettled(
+      verifiedDomains.map(async (d) => {
+        // Prefer stored ID; fall back to live domain-name lookup for pre-existing hosts
+        const npmHostId = d.npmProxyHostId ?? npmHostByDomain.get(d.domain) ?? null;
+        if (!npmHostId) {
+          failed.push({ domain: d.domain, error: "No NPM proxy host found for this domain" });
+          return;
+        }
+        try {
+          await client.proxyHosts.update(npmHostId, {
+            forward_host: cfg.frontendHost,
+            forward_port: cfg.frontendPort,
+          });
+          synced.push(d.domain);
+          // Backfill the ID if it was missing
+          if (!d.npmProxyHostId) {
+            await prisma.organizationDomain.update({
+              where: { id: d.id },
+              data: { npmProxyHostId: npmHostId },
+            }).catch(() => { /* non-critical */ });
+          }
+        } catch (err) {
+          failed.push({ domain: d.domain, error: err instanceof Error ? err.message : String(err) });
+        }
+      })
+    );
+
+    console.log(`[system/npm-config/sync] ${cfg.frontendHost}:${cfg.frontendPort} — synced ${synced.length}, failed ${failed.length}`);
+    res.json({ synced: synced.length, failed });
+  } catch (err) {
+    console.error("system/npm-config/sync error:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/apps/auth/src/npm-provision.ts
+++ b/apps/auth/src/npm-provision.ts
@@ -1,9 +1,11 @@
 import { NpmClient, NpmApiError } from "@fazri/npm-sdk";
 
-const FRONTEND_HOST = process.env.FRONTEND_HOST ?? "frontend";
-const FRONTEND_PORT = parseInt(process.env.FRONTEND_PORT ?? "3000", 10);
+export interface NpmProvisionConfig {
+  frontendHost: string;
+  frontendPort: number;
+}
 
-function createNpmClient(): NpmClient {
+export function createNpmClient(): NpmClient {
   const baseUrl = process.env.NPM_API_URL;
   if (!baseUrl) throw new Error("NPM_API_URL is not set");
 
@@ -27,22 +29,24 @@ function describeTestHttpResult(result: string | undefined): string {
   return result;
 }
 
-const PROXY_HOST_DEFAULTS = {
-  forward_scheme: "http" as const,
-  forward_host: FRONTEND_HOST,
-  forward_port: FRONTEND_PORT,
-  ssl_forced: true,
-  http2_support: true,
-  hsts_enabled: true,
-  hsts_subdomains: true,
-  trust_forwarded_proto: true,
-  caching_enabled: true,
-  block_exploits: true,
-  allow_websocket_upgrade: true,
-  enabled: true,
-};
+function buildProxyDefaults(cfg: NpmProvisionConfig) {
+  return {
+    forward_scheme: "http" as const,
+    forward_host: cfg.frontendHost,
+    forward_port: cfg.frontendPort,
+    ssl_forced: true,
+    http2_support: true,
+    hsts_enabled: true,
+    hsts_subdomains: true,
+    trust_forwarded_proto: true,
+    caching_enabled: true,
+    block_exploits: true,
+    allow_websocket_upgrade: true,
+    enabled: true,
+  };
+}
 
-export async function provisionCustomDomain(domain: string, orgName: string): Promise<{ hostId: number }> {
+export async function provisionCustomDomain(domain: string, orgName: string, cfg: NpmProvisionConfig): Promise<{ hostId: number }> {
   if (!process.env.NPM_API_URL) {
     console.warn(`[npm-provision] NPM_API_URL not set — skipping provisioning for ${domain}`);
     return { hostId: 0 };
@@ -58,7 +62,7 @@ export async function provisionCustomDomain(domain: string, orgName: string): Pr
 
   const host = await client.proxyHosts.create({
     domain_names: [domain],
-    ...PROXY_HOST_DEFAULTS,
+    ...buildProxyDefaults(cfg),
     certificate_id: "new",
     meta: { orgName },
   });
@@ -71,6 +75,7 @@ export async function reprovisionCustomDomain(
   domain: string,
   orgName: string,
   existingHostId: number | null,
+  cfg: NpmProvisionConfig,
 ): Promise<{ hostId: number }> {
   if (!process.env.NPM_API_URL) {
     console.warn(`[npm-provision] NPM_API_URL not set — skipping re-provisioning for ${domain}`);
@@ -90,7 +95,7 @@ export async function reprovisionCustomDomain(
     try {
       await client.proxyHosts.get(existingHostId);
       const updated = await client.proxyHosts.update(existingHostId, {
-        ...PROXY_HOST_DEFAULTS,
+        ...buildProxyDefaults(cfg),
         certificate_id: "new",
         meta: { orgName },
       });
@@ -108,7 +113,7 @@ export async function reprovisionCustomDomain(
   // Create new proxy host
   const host = await client.proxyHosts.create({
     domain_names: [domain],
-    ...PROXY_HOST_DEFAULTS,
+    ...buildProxyDefaults(cfg),
     certificate_id: "new",
     meta: { orgName },
   });

--- a/apps/auth/src/npm-provision.ts
+++ b/apps/auth/src/npm-provision.ts
@@ -1,0 +1,172 @@
+import { NpmClient, NpmApiError } from "@fazri/npm-sdk";
+
+const FRONTEND_HOST = process.env.FRONTEND_HOST ?? "frontend";
+const FRONTEND_PORT = parseInt(process.env.FRONTEND_PORT ?? "3000", 10);
+
+function createNpmClient(): NpmClient {
+  const baseUrl = process.env.NPM_API_URL;
+  if (!baseUrl) throw new Error("NPM_API_URL is not set");
+
+  const token = process.env.NPM_API_TOKEN;
+  if (token) return new NpmClient({ baseUrl, token });
+
+  const email = process.env.NPM_EMAIL;
+  const password = process.env.NPM_PASSWORD;
+  if (email && password) return new NpmClient({ baseUrl, email, password });
+
+  throw new Error("NPM auth not configured: set NPM_API_TOKEN or NPM_EMAIL + NPM_PASSWORD");
+}
+
+function describeTestHttpResult(result: string | undefined): string {
+  if (!result) return "unknown error";
+  if (result.startsWith("other:")) return "NPM internal error — domain may be behind a proxy or NPM cannot reach it";
+  if (result === "404") return "domain reached the server but returned 404 — likely behind Cloudflare proxy or another reverse proxy intercepting the request";
+  if (result === "no-host") return "domain does not resolve to this server — check your A record";
+  if (result === "failed") return "HTTP-01 challenge check failed — ensure port 80 is open and not blocked by firewall";
+  if (result === "wrong-data") return "HTTP-01 challenge returned unexpected data";
+  return result;
+}
+
+const PROXY_HOST_DEFAULTS = {
+  forward_scheme: "http" as const,
+  forward_host: FRONTEND_HOST,
+  forward_port: FRONTEND_PORT,
+  ssl_forced: true,
+  http2_support: true,
+  hsts_enabled: true,
+  hsts_subdomains: true,
+  trust_forwarded_proto: true,
+  caching_enabled: true,
+  block_exploits: true,
+  allow_websocket_upgrade: true,
+  enabled: true,
+};
+
+export async function provisionCustomDomain(domain: string, orgName: string): Promise<{ hostId: number }> {
+  if (!process.env.NPM_API_URL) {
+    console.warn(`[npm-provision] NPM_API_URL not set — skipping provisioning for ${domain}`);
+    return { hostId: 0 };
+  }
+
+  const client = createNpmClient();
+
+  // Pre-flight: verify the A record is pointing here before requesting the LE cert
+  const test = await client.certificates.testHttp([domain]);
+  if (test[domain] !== "ok") {
+    throw new Error(`[npm-provision] HTTP-01 pre-flight failed for ${domain}: ${describeTestHttpResult(test[domain])}`);
+  }
+
+  const host = await client.proxyHosts.create({
+    domain_names: [domain],
+    ...PROXY_HOST_DEFAULTS,
+    certificate_id: "new",
+    meta: { orgName },
+  });
+
+  console.log(`[npm-provision] ${domain} (${orgName}) → proxy host id=${host.id}, cert id=${host.certificate_id}`);
+  return { hostId: host.id };
+}
+
+export async function reprovisionCustomDomain(
+  domain: string,
+  orgName: string,
+  existingHostId: number | null,
+): Promise<{ hostId: number }> {
+  if (!process.env.NPM_API_URL) {
+    console.warn(`[npm-provision] NPM_API_URL not set — skipping re-provisioning for ${domain}`);
+    return { hostId: 0 };
+  }
+
+  const client = createNpmClient();
+
+  // Pre-flight check
+  const test = await client.certificates.testHttp([domain]);
+  if (test[domain] !== "ok") {
+    throw new Error(`[npm-provision] HTTP-01 pre-flight failed for ${domain}: ${describeTestHttpResult(test[domain])}`);
+  }
+
+  // If we have an existing host ID, try to update it to re-trigger LE cert
+  if (existingHostId) {
+    try {
+      await client.proxyHosts.get(existingHostId);
+      const updated = await client.proxyHosts.update(existingHostId, {
+        ...PROXY_HOST_DEFAULTS,
+        certificate_id: "new",
+        meta: { orgName },
+      });
+      console.log(`[npm-provision] re-provisioned ${domain} via update (host id=${updated.id})`);
+      return { hostId: updated.id };
+    } catch (err) {
+      if (err instanceof NpmApiError && err.statusCode === 404) {
+        console.warn(`[npm-provision] host id=${existingHostId} not found in NPM — will create new`);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // Create new proxy host
+  const host = await client.proxyHosts.create({
+    domain_names: [domain],
+    ...PROXY_HOST_DEFAULTS,
+    certificate_id: "new",
+    meta: { orgName },
+  });
+
+  console.log(`[npm-provision] ${domain} (${orgName}) → new proxy host id=${host.id}`);
+  return { hostId: host.id };
+}
+
+export async function deprovisionCustomDomain(domain: string, hostId?: number | null): Promise<void> {
+  if (!process.env.NPM_API_URL) return;
+
+  const client = createNpmClient();
+
+  // Prefer deleting by known ID — avoids scanning all hosts and mis-targeting a freshly re-registered domain
+  if (hostId) {
+    try {
+      await client.proxyHosts.delete(hostId);
+      console.log(`[npm-provision] deleted proxy host id=${hostId} for ${domain}`);
+      return;
+    } catch (err) {
+      if (err instanceof NpmApiError && err.statusCode === 404) {
+        console.warn(`[npm-provision] proxy host id=${hostId} already gone for ${domain}`);
+        return;
+      }
+      throw err;
+    }
+  }
+
+  // Fallback: scan by domain name (used when hostId was never stored)
+  const hosts = await client.proxyHosts.list();
+  const existing = hosts.find((h) => h.domain_names.includes(domain));
+  if (!existing) {
+    console.warn(`[npm-provision] no proxy host found for ${domain} — skipping deprovision`);
+    return;
+  }
+  await client.proxyHosts.delete(existing.id);
+  console.log(`[npm-provision] deleted proxy host id=${existing.id} for ${domain}`);
+}
+
+const NPM_SETTINGS = {
+  ssl_forced: true,
+  http2_support: true,
+  hsts_enabled: true,
+  hsts_subdomains: true,
+  trust_forwarded_proto: true,
+  caching_enabled: true,
+  block_exploits: true,
+  allow_websocket_upgrade: true,
+} as const;
+
+export async function syncNpmSettings(domain: string): Promise<{ id: number }> {
+  const client = createNpmClient();
+  const hosts = await client.proxyHosts.list();
+  const existing = hosts.find((h) => h.domain_names.includes(domain));
+  if (!existing) throw new Error(`[npm-provision] No proxy host found for ${domain}`);
+  await client.proxyHosts.update(existing.id, NPM_SETTINGS);
+  console.log(`[npm-provision] synced settings for ${domain} (host id=${existing.id})`);
+  return { id: existing.id };
+}
+
+export { NpmApiError };

--- a/apps/auth/src/npm-provision.ts
+++ b/apps/auth/src/npm-provision.ts
@@ -90,10 +90,9 @@ export async function reprovisionCustomDomain(
     throw new Error(`[npm-provision] HTTP-01 pre-flight failed for ${domain}: ${describeTestHttpResult(test[domain])}`);
   }
 
-  // If we have an existing host ID, try to update it to re-trigger LE cert
+  // If we have an existing host ID, update it to re-trigger LE cert
   if (existingHostId) {
     try {
-      await client.proxyHosts.get(existingHostId);
       const updated = await client.proxyHosts.update(existingHostId, {
         ...buildProxyDefaults(cfg),
         certificate_id: "new",
@@ -164,8 +163,23 @@ const NPM_SETTINGS = {
   allow_websocket_upgrade: true,
 } as const;
 
-export async function syncNpmSettings(domain: string): Promise<{ id: number }> {
+export async function syncNpmSettings(domain: string, hostId?: number | null): Promise<{ id: number }> {
   const client = createNpmClient();
+
+  if (hostId) {
+    try {
+      await client.proxyHosts.update(hostId, NPM_SETTINGS);
+      console.log(`[npm-provision] synced settings for ${domain} (host id=${hostId})`);
+      return { id: hostId };
+    } catch (err) {
+      if (err instanceof NpmApiError && err.statusCode === 404) {
+        console.warn(`[npm-provision] host id=${hostId} not found — falling back to domain scan`);
+      } else {
+        throw err;
+      }
+    }
+  }
+
   const hosts = await client.proxyHosts.list();
   const existing = hosts.find((h) => h.domain_names.includes(domain));
   if (!existing) throw new Error(`[npm-provision] No proxy host found for ${domain}`);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,7 +41,7 @@
     "ioredis": "^5.8.0",
     "lucide-react": "^0.544.0",
     "motion": "^12.23.22",
-    "next": "16.2.3",
+    "next": "16.2.4",
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-day-picker": "9.11.1",
@@ -63,7 +63,7 @@
     "@types/react-dom": "19.2.3",
     "@types/three": "^0.180.0",
     "eslint": "^9",
-    "eslint-config-next": "16.2.1",
+    "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"

--- a/apps/web/src/app/(app)/admin/system/page.tsx
+++ b/apps/web/src/app/(app)/admin/system/page.tsx
@@ -42,13 +42,16 @@ export default function AdminSystemPage() {
 
   useEffect(() => {
     fetch(`${AUTH_URL}/api/system/npm-config`, { credentials: "include" })
-      .then((r) => r.json())
+      .then(async (r) => {
+        if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error ?? "Failed to load");
+        return r.json();
+      })
       .then((data: NpmConfig) => {
         setFrontendHost(data.frontendHost);
         setFrontendPort(String(data.frontendPort));
         setUpdatedAt(data.updatedAt);
       })
-      .catch(() => toast.error("Failed to load current NPM config"))
+      .catch((e: unknown) => toast.error(e instanceof Error ? e.message : "Failed to load current NPM config"))
       .finally(() => setLoading(false));
   }, []);
 

--- a/apps/web/src/app/(app)/admin/system/page.tsx
+++ b/apps/web/src/app/(app)/admin/system/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { TriangleAlert } from "lucide-react";
+
+const AUTH_URL = process.env.NEXT_PUBLIC_AUTH_SERVICE_URL ?? "http://localhost:4000";
+
+interface NpmConfig {
+  frontendHost: string;
+  frontendPort: number;
+  updatedAt: string | null;
+}
+
+interface FailedSync {
+  domain: string;
+  error: string;
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-sm font-medium">{label}</Label>
+      {children}
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}
+
+export default function AdminSystemPage() {
+  const [frontendHost, setFrontendHost] = useState("");
+  const [frontendPort, setFrontendPort] = useState("");
+  const [portError, setPortError] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [lastResult, setLastResult] = useState<{ synced: number; failed: FailedSync[] } | null>(null);
+  const [updatedAt, setUpdatedAt] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${AUTH_URL}/api/system/npm-config`, { credentials: "include" })
+      .then((r) => r.json())
+      .then((data: NpmConfig) => {
+        setFrontendHost(data.frontendHost);
+        setFrontendPort(String(data.frontendPort));
+        setUpdatedAt(data.updatedAt);
+      })
+      .catch(() => toast.error("Failed to load current NPM config"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const validatePort = (val: string): boolean => {
+    const n = Number(val);
+    if (!val || !Number.isInteger(n) || n < 1 || n > 65535) {
+      setPortError("Port must be a whole number between 1 and 65535");
+      return false;
+    }
+    setPortError("");
+    return true;
+  };
+
+  const saveToDb = async (): Promise<boolean> => {
+    if (!frontendHost.trim()) {
+      toast.error("Frontend host cannot be empty");
+      return false;
+    }
+    if (!validatePort(frontendPort)) return false;
+
+    const res = await fetch(`${AUTH_URL}/api/system/npm-config`, {
+      method: "PUT",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ frontendHost: frontendHost.trim(), frontendPort: Number(frontendPort) }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      toast.error(data.error ?? "Failed to save");
+      return false;
+    }
+    setUpdatedAt(new Date().toISOString());
+    return true;
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const ok = await saveToDb();
+      if (ok) toast.success("Saved — new domains will use these values");
+    } catch {
+      toast.error("Network error — check auth service");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSync = async () => {
+    setSyncing(true);
+    setLastResult(null);
+    try {
+      // Always save current form values first so Apply always reflects what's on screen
+      const saved = await saveToDb();
+      if (!saved) { setSyncing(false); return; }
+
+      const res = await fetch(`${AUTH_URL}/api/system/npm-config/sync`, {
+        method: "POST",
+        credentials: "include",
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error ?? "Sync failed");
+        return;
+      }
+      const failed: FailedSync[] = data.failed ?? [];
+      setLastResult({ synced: data.synced, failed });
+      toast.success(`${data.synced} proxy host${data.synced !== 1 ? "s" : ""} updated`);
+      if (failed.length > 0) {
+        toast.error(`${failed.length} host${failed.length !== 1 ? "s" : ""} failed to sync`);
+      }
+    } catch {
+      toast.error("Network error — check auth service");
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const busy = saving || syncing;
+
+  return (
+    <div className="space-y-6 max-w-lg">
+      <div>
+        <h2 className="text-2xl font-semibold">System</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Configure the internal frontend target for Nginx Proxy Manager. Save stores the values to the database. Apply to All saves and immediately updates every existing proxy host.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-destructive/50 bg-destructive/5 p-4 flex gap-3">
+        <TriangleAlert className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-destructive">Changing these values will immediately affect all active subdomains.</p>
+          <p className="text-sm text-destructive/80">
+            If the new host or port is unreachable, every tenant using a custom domain will go down until corrected.
+            Do not change these unless you have already verified the new target is live and accepting traffic.
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-xl border bg-card p-5 space-y-5">
+        <div>
+          <p className="text-sm font-medium">NPM Proxy Config</p>
+          {updatedAt && (
+            <p className="text-xs text-muted-foreground mt-0.5" suppressHydrationWarning>
+              Last updated {new Date(updatedAt).toLocaleString()}
+            </p>
+          )}
+        </div>
+
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : (
+          <div className="space-y-4">
+            <Field
+              label="Frontend Host"
+              hint="Internal hostname or IP that NPM proxies to (e.g. 10.69.5.100)"
+            >
+              <Input
+                value={frontendHost}
+                onChange={(e) => setFrontendHost(e.target.value)}
+                placeholder="10.69.5.100"
+                disabled={busy}
+              />
+            </Field>
+
+            <Field
+              label="Frontend Port"
+              hint="Port your Next.js app listens on inside the network (e.g. 3000)"
+            >
+              <Input
+                value={frontendPort}
+                onChange={(e) => {
+                  setFrontendPort(e.target.value);
+                  if (portError) validatePort(e.target.value);
+                }}
+                placeholder="3000"
+                type="number"
+                min={1}
+                max={65535}
+                disabled={busy}
+              />
+              {!!portError && <p className="text-xs text-destructive mt-1">{portError}</p>}
+            </Field>
+
+            <div className="flex gap-2">
+              <Button onClick={handleSave} disabled={busy} variant="outline">
+                {saving ? "Saving…" : "Save"}
+              </Button>
+              <Button onClick={handleSync} disabled={busy}>
+                {syncing ? "Applying…" : "Apply to All Proxy Hosts"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {lastResult && lastResult.failed.length > 0 && (
+        <div className="rounded-xl border border-destructive/40 bg-destructive/5 p-4 space-y-2">
+          <p className="text-sm font-medium text-destructive">
+            {lastResult.failed.length} host{lastResult.failed.length !== 1 ? "s" : ""} failed to sync
+          </p>
+          <ul className="space-y-1">
+            {lastResult.failed.map((f) => (
+              <li key={f.domain} className="text-xs font-mono text-muted-foreground">
+                <span className="text-foreground">{f.domain}</span> — {f.error}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/dashboard/settings/custom-domain/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/settings/custom-domain/page.tsx
@@ -189,6 +189,7 @@ export default function CustomDomainPage() {
 
   // DNS check state for the cname-instructions wizard step
   const [dnsCheck, setDnsCheck] = useState<DnsCheckResult | null>(null);
+  const dnsCheckRef = useRef<DnsCheckResult | null>(null);
   const dnsCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Per-domain DNS check results for the inline list view step 2
@@ -269,12 +270,17 @@ export default function CustomDomainPage() {
     }
   }, []);
 
+  // Keep ref in sync so the interval callback always reads the latest dnsCheck status
+  useEffect(() => {
+    dnsCheckRef.current = dnsCheck;
+  }, [dnsCheck]);
+
   // DNS poll for the wizard cname-instructions state
   useEffect(() => {
     if (pageState === "cname-instructions" && cnameDomain) {
       checkDns(cnameDomain, "wizard");
       dnsCheckIntervalRef.current = setInterval(() => {
-        if (dnsCheck?.status !== "ok") checkDns(cnameDomain, "wizard");
+        if (dnsCheckRef.current?.status !== "ok") checkDns(cnameDomain, "wizard");
       }, 15_000);
     } else {
       if (dnsCheckIntervalRef.current) {
@@ -539,7 +545,7 @@ export default function CustomDomainPage() {
               </div>
               <div className="space-y-1.5">
                 <DnsRow label="Type" value="A" />
-                <DnsRow label="Name" value={cnameDomain.split(".")[0]} />
+                <DnsRow label="Name" value={cnameDomain} />
                 <DnsRow label="Value" value={SERVER_IP} />
               </div>
               <DnsStatusBanner check={dnsCheck} />

--- a/apps/web/src/app/(app)/dashboard/settings/custom-domain/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/settings/custom-domain/page.tsx
@@ -1,0 +1,703 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Globe, Plus, Trash2, CheckCircle2, Clock, Copy, RefreshCw, ArrowRight,
+  Loader2, XCircle, ShieldAlert,
+} from "lucide-react";
+
+const AUTH_URL = process.env.NEXT_PUBLIC_AUTH_SERVICE_URL ?? "http://localhost:4000";
+const SERVER_IP = process.env.NEXT_PUBLIC_FAZRI_SERVER_IP ?? "";
+
+type PageState = "loading" | "list" | "add" | "txt-verification" | "cname-instructions";
+type SslStatus = "provisioning" | "active" | "failed" | null;
+type DnsCheckStatus = "idle" | "checking" | "ok" | "not-propagated" | "wrong-ip" | "cloudflare-proxy" | "config-error";
+
+interface DomainRecord {
+  id: string;
+  domain: string;
+  ownershipVerified: boolean;
+  ownershipVerifiedAt: string | null;
+  verified: boolean;
+  verifiedAt: string | null;
+  verificationToken: string;
+  createdAt: string;
+  sslStatus: SslStatus;
+  sslProvisioningStartedAt: string | null;
+  sslError: string | null;
+  npmProxyHostId: number | null;
+}
+
+interface PendingDomain {
+  domain: string;
+  txtName: string;
+  txtValue: string;
+}
+
+interface DnsCheckResult {
+  status: DnsCheckStatus;
+  resolvedIps: string[];
+  expectedIp: string;
+  warning?: string;
+}
+
+function getEffectiveSslStatus(d: DomainRecord): SslStatus {
+  if (!d.verified) return null;
+  return d.sslStatus ?? "active"; // null = legacy record before SSL tracking
+}
+
+function copyText(text: string, label: string) {
+  navigator.clipboard.writeText(text).then(() => toast.success(`${label} copied`));
+}
+
+function DnsRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg bg-muted/60 px-3 py-2">
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        <p className="font-mono text-xs break-all">{value}</p>
+      </div>
+      <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={() => copyText(value, label)}>
+        <Copy className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1.5">
+      <label className="text-sm font-medium">{label}</label>
+      {children}
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}
+
+function DnsStatusBanner({ check }: { check: DnsCheckResult | null }) {
+  if (!check || check.status === "idle") return null;
+
+  if (check.status === "checking") {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" /> Checking DNS…
+      </div>
+    );
+  }
+  if (check.status === "ok") {
+    return (
+      <div className="flex items-center gap-2 rounded-lg bg-green-50 dark:bg-green-900/20 px-3 py-2 text-xs text-green-700 dark:text-green-400">
+        <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+        DNS verified — A record resolves to {check.expectedIp}
+      </div>
+    );
+  }
+  if (check.status === "not-propagated") {
+    return (
+      <div className="flex items-start gap-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+        <Clock className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+        <span>A record not found yet. DNS propagation can take minutes to 48 hours — checking automatically.</span>
+      </div>
+    );
+  }
+  if (check.status === "wrong-ip") {
+    return (
+      <div className="flex items-start gap-2 rounded-lg bg-red-50 dark:bg-red-900/20 px-3 py-2 text-xs text-red-700 dark:text-red-400">
+        <XCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+        <span>
+          Resolves to <code className="font-mono">{check.resolvedIps.join(", ")}</code> — expected <code className="font-mono">{check.expectedIp}</code>. Check your DNS panel.
+        </span>
+      </div>
+    );
+  }
+  if (check.status === "cloudflare-proxy") {
+    return (
+      <div className="flex items-start gap-2 rounded-lg bg-orange-50 dark:bg-orange-900/20 px-3 py-2 text-xs text-orange-700 dark:text-orange-400">
+        <ShieldAlert className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+        <span>{check.warning ?? "Domain is behind Cloudflare proxy. Disable the orange cloud for this record."}</span>
+      </div>
+    );
+  }
+  if (check.status === "config-error") {
+    return (
+      <p className="text-xs text-muted-foreground">
+        <span className="font-medium">Auth service misconfigured</span> — <code className="font-mono">FAZRI_SERVER_IP</code> is not set. Add your server&apos;s public IP to the auth service env and restart it.
+      </p>
+    );
+  }
+  return null;
+}
+
+function DomainStatusBadge({ domain }: { domain: DomainRecord }) {
+  const sslStatus = getEffectiveSslStatus(domain);
+
+  if (domain.verified) {
+    if (sslStatus === "provisioning") {
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 shrink-0">
+          <Loader2 className="h-3 w-3 animate-spin" /> Provisioning SSL…
+        </span>
+      );
+    }
+    if (sslStatus === "failed") {
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400 shrink-0">
+          <XCircle className="h-3 w-3" /> SSL Failed
+        </span>
+      );
+    }
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400 shrink-0">
+        <CheckCircle2 className="h-3 w-3" /> Active
+      </span>
+    );
+  }
+  if (domain.ownershipVerified) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 shrink-0">
+        <ArrowRight className="h-3 w-3" /> Pending DNS
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400 shrink-0">
+      <Clock className="h-3 w-3" /> Pending ownership
+    </span>
+  );
+}
+
+export default function CustomDomainPage() {
+  const { data: session } = authClient.useSession();
+  const { data: activeOrg } = authClient.useActiveOrganization();
+
+  const [isOwner, setIsOwner] = useState(false);
+  const [pageState, setPageState] = useState<PageState>("loading");
+  const [domains, setDomains] = useState<DomainRecord[]>([]);
+  const [newDomain, setNewDomain] = useState("");
+  const [registering, setRegistering] = useState(false);
+  const [verifying, setVerifying] = useState<string | null>(null);
+  const [activating, setActivating] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState<string | null>(null);
+  const [pendingDomain, setPendingDomain] = useState<PendingDomain | null>(null);
+  const [cnameDomain, setCnameDomain] = useState<string | null>(null);
+
+  // DNS check state for the cname-instructions wizard step
+  const [dnsCheck, setDnsCheck] = useState<DnsCheckResult | null>(null);
+  const dnsCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Per-domain DNS check results for the inline list view step 2
+  const [dnsByDomain, setDnsByDomain] = useState<Map<string, DnsCheckResult>>(new Map());
+
+  // Provisioning poller
+  const provisionPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!session || !activeOrg) return;
+    const members = (activeOrg as unknown as { members?: { userId: string; role: string }[] }).members ?? [];
+    const me = members.find((m) => m.userId === session.user.id);
+    setIsOwner(me?.role === "owner" || me?.role === "admin" || (session.user as Record<string, unknown>).role === "SUPER_ADMIN");
+  }, [session, activeOrg]);
+
+  const fetchDomains = useCallback(async () => {
+    if (!activeOrg) return;
+    try {
+      const res = await fetch(`${AUTH_URL}/api/domain/${activeOrg.id}`, { credentials: "include" });
+      if (!res.ok) { setDomains([]); setPageState("list"); return; }
+      const data: DomainRecord[] = await res.json();
+      setDomains(data);
+      setPageState("list");
+    } catch {
+      setDomains([]);
+      setPageState("list");
+    }
+  }, [activeOrg]);
+
+  useEffect(() => {
+    if (activeOrg) fetchDomains();
+  }, [fetchDomains, activeOrg]);
+
+  // Poll while any domain is provisioning SSL
+  useEffect(() => {
+    const hasProvisioning = domains.some((d) => d.sslStatus === "provisioning");
+    if (hasProvisioning) {
+      if (!provisionPollRef.current) {
+        provisionPollRef.current = setInterval(fetchDomains, 10_000);
+      }
+    } else {
+      if (provisionPollRef.current) {
+        clearInterval(provisionPollRef.current);
+        provisionPollRef.current = null;
+      }
+    }
+    return () => {
+      if (provisionPollRef.current) {
+        clearInterval(provisionPollRef.current);
+        provisionPollRef.current = null;
+      }
+    };
+  }, [domains, fetchDomains]);
+
+  const checkDns = useCallback(async (domain: string, target: "wizard" | string) => {
+    const setResult = (r: DnsCheckResult) => {
+      if (target === "wizard") {
+        setDnsCheck(r);
+      } else {
+        setDnsByDomain((prev) => new Map(prev).set(target, r));
+      }
+    };
+
+    setResult({ status: "checking", resolvedIps: [], expectedIp: SERVER_IP });
+
+    try {
+      const res = await fetch(`${AUTH_URL}/api/domain/check-dns?domain=${encodeURIComponent(domain)}`, {
+        credentials: "include",
+      });
+      if (res.status === 429) {
+        // silently ignore rate limit — previous result stays
+        return;
+      }
+      const body: DnsCheckResult = await res.json();
+      setResult(body);
+    } catch {
+      setResult({ status: "not-propagated", resolvedIps: [], expectedIp: SERVER_IP });
+    }
+  }, []);
+
+  // DNS poll for the wizard cname-instructions state
+  useEffect(() => {
+    if (pageState === "cname-instructions" && cnameDomain) {
+      checkDns(cnameDomain, "wizard");
+      dnsCheckIntervalRef.current = setInterval(() => {
+        if (dnsCheck?.status !== "ok") checkDns(cnameDomain, "wizard");
+      }, 15_000);
+    } else {
+      if (dnsCheckIntervalRef.current) {
+        clearInterval(dnsCheckIntervalRef.current);
+        dnsCheckIntervalRef.current = null;
+      }
+      setDnsCheck(null);
+    }
+    return () => {
+      if (dnsCheckIntervalRef.current) {
+        clearInterval(dnsCheckIntervalRef.current);
+        dnsCheckIntervalRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pageState, cnameDomain]);
+
+  const handleRegister = async () => {
+    const domain = newDomain.trim().toLowerCase();
+    if (!domain) { toast.error("Enter a domain name"); return; }
+    setRegistering(true);
+    try {
+      const res = await fetch(`${AUTH_URL}/api/domain/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ organizationId: activeOrg!.id, domain }),
+      });
+      const body = await res.json();
+      if (!res.ok) { toast.error(body.error ?? "Failed to register domain"); return; }
+      setPendingDomain({ domain: body.domain, txtName: body.txtRecord.name, txtValue: body.txtRecord.value });
+      setNewDomain("");
+      await fetchDomains();
+      setPageState("txt-verification");
+    } catch {
+      toast.error("Failed to register domain");
+    } finally {
+      setRegistering(false);
+    }
+  };
+
+  const handleVerifyOwnership = async (domain: string) => {
+    setVerifying(domain);
+    try {
+      const res = await fetch(`${AUTH_URL}/api/domain/verify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ domain }),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        toast.error(body.error ?? "TXT record not found — check your DNS panel and try again");
+      } else {
+        toast.success("Ownership verified! Now point your domain to Fazri.");
+        setCnameDomain(domain);
+        await fetchDomains();
+        setPageState("cname-instructions");
+      }
+    } catch {
+      toast.error("Verification request failed");
+    } finally {
+      setVerifying(null);
+    }
+  };
+
+  const handleActivate = async (domain: string) => {
+    setActivating(domain);
+    try {
+      const res = await fetch(`${AUTH_URL}/api/domain/activate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ domain }),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        toast.error(body.error ?? "Activation failed — ensure the A record is set");
+      } else {
+        toast.success("Domain activated! SSL certificate is being provisioned.");
+        setCnameDomain(null);
+        await fetchDomains();
+        setPageState("list");
+      }
+    } catch {
+      toast.error("Activation request failed");
+    } finally {
+      setActivating(null);
+    }
+  };
+
+  const handleRetrySSL = async (id: string, domain: string) => {
+    setActivating(domain);
+    try {
+      const res = await fetch(`${AUTH_URL}/api/domain/${id}/retry-ssl`, {
+        method: "POST",
+        credentials: "include",
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        if (res.status === 429 && body.rateLimited) {
+          toast.error("Let's Encrypt rate limit reached. Wait a few days before retrying.");
+        } else {
+          toast.error(body.error ?? "Failed to retry SSL provisioning");
+        }
+      } else {
+        toast.success("SSL retry started. This may take a few minutes.");
+        await fetchDomains();
+      }
+    } catch {
+      toast.error("Request failed");
+    } finally {
+      setActivating(null);
+    }
+  };
+
+  const handleSyncNpm = async (id: string, domain: string) => {
+    setSyncing(id);
+    try {
+      const res = await fetch(`${AUTH_URL}/api/domain/${id}/sync-npm`, {
+        method: "POST",
+        credentials: "include",
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        toast.error(body.error ?? "Failed to sync NPM settings");
+      } else {
+        toast.success(`NPM settings synced for ${domain}`);
+      }
+    } catch {
+      toast.error("Sync request failed");
+    } finally {
+      setSyncing(null);
+    }
+  };
+
+  const handleDelete = async (id: string, domain: string) => {
+    setDeleting(id);
+    try {
+      const res = await fetch(`${AUTH_URL}/api/domain/${id}`, { method: "DELETE", credentials: "include" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        toast.error((body as { error?: string }).error ?? "Failed to remove domain");
+      } else {
+        toast.success(`${domain} removed`);
+        await fetchDomains();
+      }
+    } catch {
+      toast.error("Failed to remove domain");
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  if (!activeOrg) {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-2xl font-semibold">Custom Domain</h2>
+        <div className="rounded-xl border bg-card p-6">
+          <p className="text-sm text-muted-foreground">No active organization. Join or create one to configure a custom domain.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h2 className="text-2xl font-semibold">Custom Domain</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Map a university-branded URL to <span className="font-medium">{activeOrg.name}</span>
+        </p>
+      </div>
+
+      <div className="rounded-xl border bg-card p-6 space-y-6">
+
+        {/* Org context row */}
+        <div className="flex items-center gap-3 rounded-lg bg-muted/50 border px-3 py-2.5">
+          <Globe className="h-4 w-4 text-muted-foreground shrink-0" />
+          <div className="min-w-0">
+            <p className="text-xs text-muted-foreground">Configuring for organization</p>
+            <p className="text-sm font-medium truncate">{activeOrg.name}</p>
+          </div>
+          <code className="ml-auto text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
+            {activeOrg.slug}
+          </code>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <h3 className="font-medium text-sm">Domains</h3>
+          {isOwner && pageState === "list" && (
+            <Button size="sm" variant="outline" onClick={() => setPageState("add")}>
+              <Plus className="h-3.5 w-3.5 mr-1.5" />Add domain
+            </Button>
+          )}
+        </div>
+
+        <AnimatePresence mode="wait">
+
+          {pageState === "loading" && (
+            <motion.div key="loading" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="space-y-2">
+              {Array.from({ length: 2 }).map((_, i) => <div key={i} className="h-16 animate-pulse rounded-lg bg-muted" />)}
+            </motion.div>
+          )}
+
+          {pageState === "add" && (
+            <motion.div key="add" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="space-y-4">
+              <Field label="Domain" hint="Full subdomain you control, e.g. fazri.iitg.ac.in">
+                <Input
+                  value={newDomain}
+                  onChange={(e) => setNewDomain(e.target.value)}
+                  placeholder="fazri.youruniversity.edu"
+                  onKeyDown={(e) => e.key === "Enter" && handleRegister()}
+                  autoFocus
+                />
+              </Field>
+              <div className="flex gap-2">
+                <Button size="sm" onClick={handleRegister} disabled={registering}>
+                  {registering ? "Registering…" : "Register Domain"}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => { setNewDomain(""); setPageState("list"); }}>Cancel</Button>
+              </div>
+            </motion.div>
+          )}
+
+          {/* Step 1 — prove domain ownership via TXT record */}
+          {pageState === "txt-verification" && pendingDomain && (
+            <motion.div key="txt" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="space-y-5">
+              <div className="rounded-lg border bg-muted/50 p-4 space-y-1">
+                <p className="text-sm font-medium">Step 1 of 2 — Verify domain ownership</p>
+                <p className="text-xs text-muted-foreground">
+                  Add this TXT record to your DNS panel to prove you own{" "}
+                  <code className="bg-muted px-1 py-0.5 rounded">{pendingDomain.domain}</code>.
+                  Once the record propagates, click Verify.
+                </p>
+              </div>
+              <div className="space-y-1.5">
+                <DnsRow label="Type" value="TXT" />
+                <DnsRow label="Name" value={pendingDomain.txtName} />
+                <DnsRow label="Value" value={pendingDomain.txtValue} />
+              </div>
+              <div className="flex gap-2">
+                <Button size="sm" onClick={() => handleVerifyOwnership(pendingDomain.domain)} disabled={verifying === pendingDomain.domain}>
+                  <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${verifying === pendingDomain.domain ? "animate-spin" : ""}`} />
+                  {verifying === pendingDomain.domain ? "Checking…" : "Verify Ownership"}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => setPageState("list")}>Do this later</Button>
+              </div>
+            </motion.div>
+          )}
+
+          {/* Step 2 — point domain via A record then activate */}
+          {pageState === "cname-instructions" && cnameDomain && (
+            <motion.div key="cname" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="space-y-5">
+              <div className="rounded-lg border bg-muted/50 p-4 space-y-1">
+                <p className="text-sm font-medium">Step 2 of 2 — Point your domain to Fazri</p>
+                <p className="text-xs text-muted-foreground">
+                  Add this A record so{" "}
+                  <code className="bg-muted px-1 py-0.5 rounded">{cnameDomain}</code> resolves to your Fazri instance,
+                  then click Activate to provision the SSL certificate.
+                </p>
+              </div>
+              <div className="space-y-1.5">
+                <DnsRow label="Type" value="A" />
+                <DnsRow label="Name" value={cnameDomain.split(".")[0]} />
+                <DnsRow label="Value" value={SERVER_IP} />
+              </div>
+              <DnsStatusBanner check={dnsCheck} />
+              <div className="flex gap-2">
+                <Button size="sm" onClick={() => handleActivate(cnameDomain)} disabled={activating === cnameDomain || dnsCheck?.status !== "ok"}>
+                  <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${activating === cnameDomain ? "animate-spin" : ""}`} />
+                  {activating === cnameDomain ? "Activating…" : "Activate Domain"}
+                </Button>
+                <Button
+                  size="sm" variant="outline"
+                  disabled={dnsCheck?.status === "checking"}
+                  onClick={() => checkDns(cnameDomain, "wizard")}
+                >
+                  {dnsCheck?.status === "checking"
+                    ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    : <RefreshCw className="h-3.5 w-3.5" />}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => { setPageState("list"); setCnameDomain(null); }}>Do this later</Button>
+              </div>
+            </motion.div>
+          )}
+
+          {pageState === "list" && (
+            <motion.div key="list" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="space-y-3">
+              {domains.length === 0 ? (
+                <div className="space-y-3">
+                  <p className="text-sm text-muted-foreground">
+                    {isOwner
+                      ? "No custom domains configured. Add one so your university can access Fazri from their own URL."
+                      : "No custom domains configured. Only organization owners can add custom domains."}
+                  </p>
+                  {isOwner && <Button size="sm" onClick={() => setPageState("add")}>Add domain</Button>}
+                </div>
+              ) : (
+                <>
+                  {domains.map((d) => {
+                    const sslStatus = getEffectiveSslStatus(d);
+                    const inlineDnsCheck = dnsByDomain.get(d.id) ?? null;
+                    return (
+                      <div key={d.id} className="rounded-lg border p-4 space-y-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="flex items-center gap-2 min-w-0">
+                            <span className="text-sm font-medium truncate">{d.domain}</span>
+                            <DomainStatusBadge domain={d} />
+                          </div>
+                          {isOwner && (
+                            <div className="flex items-center gap-1 shrink-0">
+                              {d.verified && sslStatus === "active" && (
+                                <Button
+                                  variant="ghost" size="icon"
+                                  className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                                  disabled={syncing === d.id}
+                                  title="Sync NPM settings (SSL, HSTS, HTTP/2)"
+                                  onClick={() => handleSyncNpm(d.id, d.domain)}
+                                >
+                                  <RefreshCw className={`h-3.5 w-3.5 ${syncing === d.id ? "animate-spin" : ""}`} />
+                                </Button>
+                              )}
+                              <Button
+                                variant="ghost" size="icon"
+                                className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10"
+                                disabled={deleting === d.id}
+                                onClick={() => handleDelete(d.id, d.domain)}
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </div>
+                          )}
+                        </div>
+
+                        <p className="text-xs text-muted-foreground">
+                          Added {new Date(d.createdAt).toLocaleDateString()}
+                          {d.verifiedAt && ` · Active since ${new Date(d.verifiedAt).toLocaleDateString()}`}
+                        </p>
+
+                        {/* Step 1 inline: ownership not verified yet */}
+                        {!d.ownershipVerified && isOwner && (
+                          <div className="space-y-3 pt-2 border-t">
+                            <p className="text-xs font-medium text-muted-foreground">Add this TXT record to verify ownership</p>
+                            <div className="space-y-1.5">
+                              <DnsRow label="Name" value={`_fazri-verify.${d.domain}`} />
+                              <DnsRow label="Value" value={`fazri-verify=${d.verificationToken}`} />
+                            </div>
+                            <Button size="sm" variant="outline" onClick={() => handleVerifyOwnership(d.domain)} disabled={verifying === d.domain}>
+                              <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${verifying === d.domain ? "animate-spin" : ""}`} />
+                              {verifying === d.domain ? "Checking…" : "Verify Ownership"}
+                            </Button>
+                          </div>
+                        )}
+
+                        {/* Step 2 inline: ownership verified, A record not set yet */}
+                        {d.ownershipVerified && !d.verified && isOwner && (
+                          <div className="space-y-3 pt-2 border-t">
+                            <p className="text-xs font-medium text-muted-foreground">Add this A record to point your domain</p>
+                            <div className="space-y-1.5">
+                              <DnsRow label="Name" value={d.domain.split(".")[0]} />
+                              <DnsRow label="Value" value={SERVER_IP} />
+                            </div>
+                            <DnsStatusBanner check={inlineDnsCheck} />
+                            <div className="flex gap-2">
+                              <Button
+                                size="sm" variant="outline"
+                                onClick={() => handleActivate(d.domain)}
+                                disabled={activating === d.domain || inlineDnsCheck?.status !== "ok"}
+                              >
+                                <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${activating === d.domain ? "animate-spin" : ""}`} />
+                                {activating === d.domain ? "Activating…" : "Activate Domain"}
+                              </Button>
+                              <Button
+                                size="sm" variant="outline"
+                                disabled={inlineDnsCheck?.status === "checking"}
+                                onClick={() => checkDns(d.domain, d.id)}
+                              >
+                                {inlineDnsCheck?.status === "checking"
+                                  ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                  : <RefreshCw className="h-3.5 w-3.5" />}
+                              </Button>
+                            </div>
+                          </div>
+                        )}
+
+                        {/* SSL failed: show error and retry */}
+                        {d.verified && sslStatus === "failed" && isOwner && (
+                          <div className="space-y-2 pt-2 border-t">
+                            {d.sslError && (
+                              <p className="text-xs text-muted-foreground line-clamp-2">{d.sslError}</p>
+                            )}
+                            {d.sslError && /too many certificates|rateLimited/i.test(d.sslError) ? (
+                              <p className="text-xs text-amber-600 dark:text-amber-400">
+                                Let&apos;s Encrypt rate limited (5 certs/week). Wait a few days before retrying.
+                              </p>
+                            ) : (
+                              <Button
+                                size="sm" variant="outline"
+                                onClick={() => handleRetrySSL(d.id, d.domain)}
+                                disabled={activating === d.domain}
+                              >
+                                <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${activating === d.domain ? "animate-spin" : ""}`} />
+                                {activating === d.domain ? "Retrying…" : "Retry SSL"}
+                              </Button>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+
+                  {isOwner && (
+                    <Button size="sm" variant="outline" onClick={() => setPageState("add")}>
+                      <Plus className="h-3.5 w-3.5 mr-1.5" />Add another domain
+                    </Button>
+                  )}
+                </>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/AdminSubNav.tsx
+++ b/apps/web/src/components/admin/AdminSubNav.tsx
@@ -11,6 +11,7 @@ const NAV_ITEMS = [
   { label: "Analytics", href: "/admin/analytics" },
   { label: "Sessions", href: "/admin/sessions" },
   { label: "Onboarding", href: "/admin/onboarding" },
+  { label: "System", href: "/admin/system" },
 ];
 
 export function AdminSubNav() {

--- a/apps/web/src/components/sidebar-layout.tsx
+++ b/apps/web/src/components/sidebar-layout.tsx
@@ -34,6 +34,8 @@ import {
   Radio,
   Heart,
   Settings,
+  KeyRound,
+  Globe,
 } from "lucide-react"
 import { useActiveAlertCount } from "@/hooks/useAlerts"
 import { OrgSwitcher } from "@/components/layout/OrgSwitcher"
@@ -165,6 +167,30 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
                         <Link href={`${BASE}/system`} className="flex items-center gap-3">
                           <Heart className="h-5 w-5 flex-shrink-0" />
                           <span className="truncate">System Health</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  </SidebarMenu>
+                </SidebarGroup>
+
+                <SidebarSeparator />
+
+                <SidebarGroup>
+                  <SidebarGroupLabel>Settings</SidebarGroupLabel>
+                  <SidebarMenu>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild data-active={isActive(`${BASE}/settings/sso`)}>
+                        <Link href={`${BASE}/settings/sso`} className="flex items-center gap-3">
+                          <KeyRound className="h-5 w-5 flex-shrink-0" />
+                          <span className="truncate">Single Sign-On</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton asChild data-active={isActive(`${BASE}/settings/custom-domain`)}>
+                        <Link href={`${BASE}/settings/custom-domain`} className="flex items-center gap-3">
+                          <Globe className="h-5 w-5 flex-shrink-0" />
+                          <span className="truncate">Custom Domain</span>
                         </Link>
                       </SidebarMenuButton>
                     </SidebarMenuItem>

--- a/apps/web/src/components/sidebar-layout.tsx
+++ b/apps/web/src/components/sidebar-layout.tsx
@@ -47,7 +47,7 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const router = useRouter()
   const { data: session, isPending } = useSession()
-  const isActive = (href: string) => pathname === href
+  const isActive = (href: string) => pathname === href || pathname.startsWith(href + "/")
 
   const user = session?.user as Record<string, unknown> | undefined
   const isSuperAdmin = user?.role === "SUPER_ADMIN"

--- a/apps/web/src/lib/org-context.tsx
+++ b/apps/web/src/lib/org-context.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import { createContext, useContext } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import { useSession } from "@/lib/auth-client";
+
+const ORG_COOKIE = "fazri-org-id";
+
+function readOrgCookie(): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${ORG_COOKIE}=([^;]+)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}
 
 interface OrgContextValue {
   organizationId: string | null;
@@ -18,11 +26,19 @@ const OrgCtx = createContext<OrgContextValue>({
 export function OrgProvider({ children }: { children: React.ReactNode }) {
   const { data: session, isPending } = useSession();
   const rawSession = session?.session as Record<string, unknown> | undefined;
+  const [cookieOrgId, setCookieOrgId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCookieOrgId(readOrgCookie());
+  }, []);
+
+  const sessionOrgId = (rawSession?.activeOrganizationId as string) ?? null;
 
   return (
     <OrgCtx.Provider
       value={{
-        organizationId: (rawSession?.activeOrganizationId as string) ?? null,
+        // Session takes priority; fall back to hostname-resolved cookie (custom/sub domains)
+        organizationId: sessionOrgId ?? cookieOrgId,
         organizationSlug: null,
         isLoaded: !isPending,
       }}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -3,14 +3,14 @@ import { NextRequest, NextResponse } from "next/server";
 const AUTH_SERVICE_URL = process.env.NEXT_PUBLIC_AUTH_SERVICE_URL ?? "http://localhost:4000";
 const ORG_COOKIE = "fazri-org-id";
 const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 500;
 
 interface OrgResolution {
   organizationId: string;
   slug: string;
-  name: string;
 }
 
-// In-memory cache for hostname → orgId. Persists for the edge worker lifetime (~minutes).
+// In-memory cache for hostname → org. Persists for the edge worker lifetime (~minutes).
 const hostnameCache = new Map<string, { data: OrgResolution; expiresAt: number }>();
 
 async function resolveOrgFromHostname(hostname: string): Promise<OrgResolution | null> {
@@ -24,6 +24,12 @@ async function resolveOrgFromHostname(hostname: string): Promise<OrgResolution |
     );
     if (!res.ok) return null;
     const data = (await res.json()) as OrgResolution;
+
+    // Evict oldest entry when at cap to keep the map bounded
+    if (hostnameCache.size >= MAX_CACHE_ENTRIES) {
+      const oldestKey = hostnameCache.keys().next().value;
+      if (oldestKey) hostnameCache.delete(oldestKey);
+    }
     hostnameCache.set(hostname, { data, expiresAt: Date.now() + CACHE_TTL_MS });
     return data;
   } catch {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const AUTH_SERVICE_URL = process.env.NEXT_PUBLIC_AUTH_SERVICE_URL ?? "http://localhost:4000";
+const ORG_COOKIE = "fazri-org-id";
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface OrgResolution {
+  organizationId: string;
+  slug: string;
+  name: string;
+}
+
+// In-memory cache for hostname → orgId. Persists for the edge worker lifetime (~minutes).
+const hostnameCache = new Map<string, { data: OrgResolution; expiresAt: number }>();
+
+async function resolveOrgFromHostname(hostname: string): Promise<OrgResolution | null> {
+  const cached = hostnameCache.get(hostname);
+  if (cached && cached.expiresAt > Date.now()) return cached.data;
+
+  try {
+    const res = await fetch(
+      `${AUTH_SERVICE_URL}/api/org/resolve?hostname=${encodeURIComponent(hostname)}`,
+      { cache: "no-store" }
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as OrgResolution;
+    hostnameCache.set(hostname, { data, expiresAt: Date.now() + CACHE_TTL_MS });
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export async function proxy(request: NextRequest) {
+  const rawHostname =
+    request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "";
+
+  // Strip port (e.g., localhost:3000 → localhost)
+  const hostname = rawHostname.split(":")[0];
+
+  const org = await resolveOrgFromHostname(hostname);
+
+  const requestHeaders = new Headers(request.headers);
+  if (org) {
+    requestHeaders.set("x-org-id", org.organizationId);
+  }
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+
+  if (org) {
+    response.cookies.set(ORG_COOKIE, org.organizationId, {
+      path: "/",
+      sameSite: "lax",
+      maxAge: 300, // 5 minutes — matches CACHE_TTL_MS
+    });
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon\\.ico|api/auth).*)"],
+};

--- a/env.prod.example
+++ b/env.prod.example
@@ -108,3 +108,28 @@ VERTEX_LOCATION=us-central1
 
 # ─── Discord alert webhook (optional) ────────────────────────────────────────
 DISCORD_WEBHOOK_URL=            # Paste Discord incoming webhook URL or leave blank
+
+# ─── Multi-tenant domain routing ──────────────────────────────────────────────
+# Base domain for Fazri-owned subdomains (e.g. iitg.fazri.in → slug=iitg)
+FAZRI_BASE_DOMAIN=fazri.in      # [REQUIRED for prod] Change to your root domain
+
+# CNAME target shown to university IT admins when they set up custom domains
+# CNAME target for university custom domains — must be a DNS-only (non-proxied) Cloudflare record
+# pointing to your NPM instance's real IP. Do NOT use a Cloudflare-proxied hostname here.
+# Example: create cname-target.rayzrsole.com in Cloudflare with orange cloud OFF → NPM IP
+NEXT_PUBLIC_FAZRI_APP_DOMAIN=cname-target.rayzrsole.com
+
+# Cross-subdomain cookie domain — must start with dot
+COOKIE_DOMAIN=.fazri.in         # [REQUIRED for prod] Must match FAZRI_BASE_DOMAIN
+
+# ─── Nginx Proxy Manager (NPM) — custom domain cert provisioning ──────────────
+# Only required when universities use their own domains (e.g. fazri.iitg.ac.in)
+NPM_API_URL=https://npm.rdpdc.in         # NPM instance base URL
+# Auth: use token (preferred) OR email + password — token takes priority if both are set
+NPM_API_TOKEN=CHANGE_ME_NPM_JWT_TOKEN   # Long-lived NPM API token (get via NPM UI → Settings)
+NPM_EMAIL=                              # NPM admin email (alternative to token)
+NPM_PASSWORD=                           # NPM admin password (alternative to token)
+
+# Next.js container name/IP as seen from the auth service (used when creating NPM proxy host)
+FRONTEND_HOST=frontend
+FRONTEND_PORT=3000

--- a/env.prod.example
+++ b/env.prod.example
@@ -117,14 +117,14 @@ FAZRI_BASE_DOMAIN=fazri.in      # [REQUIRED for prod] Change to your root domain
 # CNAME target for university custom domains — must be a DNS-only (non-proxied) Cloudflare record
 # pointing to your NPM instance's real IP. Do NOT use a Cloudflare-proxied hostname here.
 # Example: create cname-target.rayzrsole.com in Cloudflare with orange cloud OFF → NPM IP
-NEXT_PUBLIC_FAZRI_APP_DOMAIN=cname-target.rayzrsole.com
+NEXT_PUBLIC_FAZRI_APP_DOMAIN=<your-app-domain>
 
 # Cross-subdomain cookie domain — must start with dot
 COOKIE_DOMAIN=.fazri.in         # [REQUIRED for prod] Must match FAZRI_BASE_DOMAIN
 
 # ─── Nginx Proxy Manager (NPM) — custom domain cert provisioning ──────────────
 # Only required when universities use their own domains (e.g. fazri.iitg.ac.in)
-NPM_API_URL=https://npm.rdpdc.in         # NPM instance base URL
+NPM_API_URL=https://npm.example.com      # NPM instance base URL
 # Auth: use token (preferred) OR email + password — token takes priority if both are set
 NPM_API_TOKEN=CHANGE_ME_NPM_JWT_TOKEN   # Long-lived NPM API token (get via NPM UI → Settings)
 NPM_EMAIL=                              # NPM admin email (alternative to token)

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -93,14 +93,32 @@ enum UserRole {
 }
 
 model organization {
-  id          String       @id
-  name        String
-  slug        String       @unique
-  logo        String?
-  createdAt   DateTime
-  metadata    String?
-  members     member[]
-  invitations invitation[]
+  id            String               @id
+  name          String
+  slug          String               @unique
+  logo          String?
+  createdAt     DateTime
+  metadata      String?
+  members       member[]
+  invitations   invitation[]
+  customDomains organizationDomain[]
+}
+
+model organizationDomain {
+  id                       String    @id @default(cuid())
+  organizationId           String
+  organization             organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  domain                   String    @unique
+  verificationToken        String    @default(cuid())
+  ownershipVerified        Boolean   @default(false)
+  ownershipVerifiedAt      DateTime?
+  verified                 Boolean   @default(false)
+  verifiedAt               DateTime?
+  createdAt                DateTime  @default(now())
+  sslStatus                String?
+  sslProvisioningStartedAt DateTime?
+  sslError                 String?
+  npmProxyHostId           Int?
 }
 
 model member {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -153,3 +153,9 @@ model ssoProvider {
   organizationId String?
   domain         String?
 }
+
+model systemSetting {
+  key       String   @id
+  value     String
+  updatedAt DateTime @updatedAt
+}

--- a/packages/npm-sdk/.gitignore
+++ b/packages/npm-sdk/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tsbuildinfo

--- a/packages/npm-sdk/README.md
+++ b/packages/npm-sdk/README.md
@@ -1,0 +1,264 @@
+# @fazri/npm-sdk
+
+Internal TypeScript SDK for [Nginx Proxy Manager](https://nginxproxymanager.com/) API. Used by `apps/auth` for programmatic proxy host management and SSL certificate provisioning.
+
+Zero dependencies. Works with Node.js 18+.
+
+## Usage
+
+```typescript
+import { NpmClient } from '@fazri/npm-sdk';
+
+const client = new NpmClient({
+  baseUrl: 'http://127.0.0.1:81',
+  email: 'admin@example.com',
+  password: 'your-password',
+});
+
+// List all proxy hosts
+const hosts = await client.proxyHosts.list();
+
+// Create a proxy host with auto SSL
+const host = await client.proxyHosts.create({
+  domain_names: ['app.example.com'],
+  forward_scheme: 'http',
+  forward_host: '127.0.0.1',
+  forward_port: 3000,
+  certificate_id: 'new',
+  ssl_forced: true,
+  allow_websocket_upgrade: true,
+});
+```
+
+## Authentication
+
+The SDK supports two authentication methods. You can use either or both.
+
+**Credentials (auto-managed):** The SDK logs in on the first request and refreshes the token automatically when it expires.
+
+```typescript
+const client = new NpmClient({
+  baseUrl: 'http://127.0.0.1:81',
+  email: 'admin@example.com',
+  password: 'your-password',
+});
+```
+
+**Token (manual):** Use a pre-obtained Bearer token directly.
+
+```typescript
+const client = new NpmClient({
+  baseUrl: 'http://127.0.0.1:81',
+  token: 'eyJhbGciOi...',
+});
+```
+
+**Both:** If both are provided, the token is used first. Credentials are used as fallback when the token expires.
+
+You can also call `login()` and `refreshToken()` manually:
+
+```typescript
+const tokenData = await client.login();
+console.log(tokenData.token, tokenData.expires);
+
+const refreshed = await client.refreshToken();
+```
+
+## API
+
+### Proxy Hosts
+
+```typescript
+// List all proxy hosts
+const hosts = await client.proxyHosts.list();
+
+// List with expanded relations
+const hosts = await client.proxyHosts.list({
+  expand: ['owner', 'certificate', 'access_list'],
+  query: 'example.com',
+});
+
+// Get a single proxy host
+const host = await client.proxyHosts.get(1);
+
+// Create a proxy host
+const host = await client.proxyHosts.create({
+  domain_names: ['app.example.com'],
+  forward_scheme: 'http',
+  forward_host: '127.0.0.1',
+  forward_port: 3000,
+  certificate_id: 'new',    // auto-provision Let's Encrypt SSL
+  ssl_forced: true,
+  http2_support: true,
+  block_exploits: true,
+  allow_websocket_upgrade: true,
+  advanced_config: '',       // raw nginx config (optional)
+  locations: [],             // custom location blocks (optional)
+});
+
+// Update a proxy host (partial update, only send changed fields)
+const updated = await client.proxyHosts.update(1, {
+  forward_port: 4000,
+  ssl_forced: true,
+});
+
+// Delete a proxy host
+await client.proxyHosts.delete(1);
+
+// Enable / Disable
+await client.proxyHosts.enable(1);
+await client.proxyHosts.disable(1);
+```
+
+### Certificates
+
+```typescript
+// List all certificates
+const certs = await client.certificates.list();
+
+// Get a single certificate
+const cert = await client.certificates.get(1);
+
+// Create a Let's Encrypt certificate (HTTP-01 challenge)
+const cert = await client.certificates.create({
+  provider: 'letsencrypt',
+  domain_names: ['app.example.com'],
+  meta: { key_type: 'ecdsa' },
+});
+
+// Create a Let's Encrypt certificate (DNS challenge)
+const cert = await client.certificates.create({
+  provider: 'letsencrypt',
+  domain_names: ['*.example.com'],
+  meta: {
+    dns_challenge: true,
+    dns_provider: 'cloudflare',
+    dns_provider_credentials: 'dns_cloudflare_api_token = xxxxx',
+    propagation_seconds: 30,
+    key_type: 'ecdsa',
+  },
+});
+
+// Renew a certificate
+const renewed = await client.certificates.renew(1);
+
+// Delete a certificate
+await client.certificates.delete(1);
+
+// Test HTTP reachability before requesting a cert
+const results = await client.certificates.testHttp(['app.example.com']);
+// { 'app.example.com': 'ok' }
+```
+
+## SSL with Proxy Hosts
+
+The `certificate_id` field on proxy hosts controls SSL:
+
+| Value | Behavior |
+|-------|----------|
+| `'new'` | Auto-provision a Let's Encrypt certificate using the proxy host's domains |
+| `0` (or omit) | No SSL |
+| `<number>` | Use an existing certificate by ID |
+
+When a certificate is assigned, SSL options cascade:
+- No certificate = `ssl_forced`, `http2_support` forced to `false`
+- No `ssl_forced` = `hsts_enabled` forced to `false`
+- No `hsts_enabled` = `hsts_subdomains` forced to `false`
+
+## Custom Location Blocks
+
+Proxy hosts support custom location blocks for path-based routing:
+
+```typescript
+await client.proxyHosts.create({
+  domain_names: ['app.example.com'],
+  forward_scheme: 'http',
+  forward_host: '127.0.0.1',
+  forward_port: 3000,
+  locations: [
+    {
+      path: '/api',
+      forward_scheme: 'http',
+      forward_host: '127.0.0.1',
+      forward_port: 8080,
+    },
+    {
+      path: '/ws',
+      forward_scheme: 'http',
+      forward_host: '127.0.0.1',
+      forward_port: 8081,
+      advanced_config: 'proxy_read_timeout 86400;',
+    },
+  ],
+});
+```
+
+## Advanced Nginx Config
+
+The `advanced_config` field injects raw nginx directives into the server block. Use with caution — syntax errors will break the proxy host.
+
+```typescript
+await client.proxyHosts.create({
+  domain_names: ['app.example.com'],
+  forward_scheme: 'http',
+  forward_host: '127.0.0.1',
+  forward_port: 3000,
+  advanced_config: `
+    proxy_read_timeout 86400;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  `,
+});
+```
+
+## Error Handling
+
+All API errors throw `NpmApiError` with the status code and error body:
+
+```typescript
+import { NpmClient, NpmApiError } from '@fazri/npm-sdk';
+
+try {
+  await client.proxyHosts.create({ ... });
+} catch (err) {
+  if (err instanceof NpmApiError) {
+    console.error(err.statusCode);  // 400, 401, 404, etc.
+    console.error(err.message);     // "Domains are invalid"
+    console.error(err.body);        // { error: { code: 400, message: '...' } }
+  }
+}
+```
+
+## Timeouts
+
+Default timeout is 30 seconds for standard API calls. Certificate creation and renewal use a 15-minute timeout to accommodate Let's Encrypt provisioning delays.
+
+## Security
+
+- **Clear credentials when done**: Call `client.clearCredentials()` to remove sensitive data from memory.
+- **Use tokens when possible**: Prefer Bearer tokens over email/password to minimize credential exposure.
+- **Domain validation**: The SDK rejects characters that would break nginx `server_name` (spaces, semicolons, braces).
+- **Advanced config validation**: Checks for patterns that would break out of the server block context.
+
+## TypeScript
+
+Full type definitions are included. All payload interfaces are exported:
+
+```typescript
+import type {
+  ProxyHost,
+  CreateProxyHostPayload,
+  UpdateProxyHostPayload,
+  Certificate,
+  CreateLetsEncryptCertPayload,
+  CreateCustomCertPayload,
+  ProxyHostLocation,
+  TestHttpResult,
+} from '@fazri/npm-sdk';
+```
+
+## Compatibility
+
+- **Node.js:** 18+ (uses native `fetch`)
+- **Nginx Proxy Manager:** v2.x (tested with v2.13.7)
+- **Module format:** CommonJS (internal monorepo build)

--- a/packages/npm-sdk/package.json
+++ b/packages/npm-sdk/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@fazri/npm-sdk",
+  "version": "0.1.1",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/npm-sdk/package.json
+++ b/packages/npm-sdk/package.json
@@ -5,7 +5,10 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/packages/npm-sdk/src/certificates.ts
+++ b/packages/npm-sdk/src/certificates.ts
@@ -1,0 +1,73 @@
+import type {
+  RequestFn,
+  Certificate,
+  CreateCertificatePayload,
+  TestHttpResult,
+} from './types';
+import { validateDomainNames } from './validation';
+
+const CERT_TIMEOUT = 900_000; // 15 minutes, matching NPM backend
+
+export class Certificates {
+  constructor(private request: RequestFn) {}
+
+  async list(options?: {
+    expand?: ('owner' | 'proxy_hosts' | 'redirection_hosts' | 'dead_hosts' | 'streams')[];
+    query?: string;
+  }): Promise<Certificate[]> {
+    const params: Record<string, string> = {};
+
+    if (options?.expand?.length) {
+      params.expand = options.expand.join(',');
+    }
+    if (options?.query) {
+      params.query = options.query;
+    }
+
+    return this.request<Certificate[]>('GET', '/api/nginx/certificates', { params });
+  }
+
+  async get(
+    id: number,
+    options?: {
+      expand?: ('owner' | 'proxy_hosts' | 'redirection_hosts' | 'dead_hosts' | 'streams')[];
+    },
+  ): Promise<Certificate> {
+    const params: Record<string, string> = {};
+
+    if (options?.expand?.length) {
+      params.expand = options.expand.join(',');
+    }
+
+    return this.request<Certificate>('GET', `/api/nginx/certificates/${id}`, { params });
+  }
+
+  async create(payload: CreateCertificatePayload): Promise<Certificate> {
+    if (payload.provider === 'letsencrypt' && 'domain_names' in payload) {
+      validateDomainNames(payload.domain_names);
+    }
+
+    return this.request<Certificate>('POST', '/api/nginx/certificates', {
+      body: payload,
+      timeout: CERT_TIMEOUT,
+    });
+  }
+
+  async delete(id: number): Promise<boolean> {
+    return this.request<boolean>('DELETE', `/api/nginx/certificates/${id}`);
+  }
+
+  async renew(id: number): Promise<Certificate> {
+    return this.request<Certificate>('POST', `/api/nginx/certificates/${id}/renew`, {
+      timeout: CERT_TIMEOUT,
+    });
+  }
+
+  async testHttp(domains: string[]): Promise<TestHttpResult> {
+    validateDomainNames(domains);
+
+    return this.request<TestHttpResult>('POST', '/api/nginx/certificates/test-http', {
+      body: { domains },
+    });
+  }
+}

--- a/packages/npm-sdk/src/client.ts
+++ b/packages/npm-sdk/src/client.ts
@@ -140,8 +140,6 @@ export class NpmClient {
 
         return await res.json() as T;
       } catch (err) {
-        clearTimeout(timer);
-
         if (err instanceof Error && err.name === 'AbortError') {
           throw new Error(`Request timeout after ${timeoutMs}ms: ${method} ${path}`);
         }
@@ -173,6 +171,10 @@ export class NpmClient {
     if (this.email && this.password) {
       await this.login();
       return;
+    }
+
+    if (this.token && (!this.tokenExpires || this.tokenExpires <= new Date())) {
+      throw new Error('NPM token expired and no credentials available for refresh');
     }
 
     if (!this.token) {

--- a/packages/npm-sdk/src/client.ts
+++ b/packages/npm-sdk/src/client.ts
@@ -30,7 +30,8 @@ export class NpmClient {
   public readonly certificates: Certificates;
 
   constructor(config: NpmClientConfig) {
-    const url = config.baseUrl.replace(/\/+$/, '');
+    let url = config.baseUrl;
+    while (url.endsWith('/')) url = url.slice(0, -1);
     try {
       const parsed = new URL(url);
       if (!['http:', 'https:'].includes(parsed.protocol)) {

--- a/packages/npm-sdk/src/client.ts
+++ b/packages/npm-sdk/src/client.ts
@@ -1,0 +1,191 @@
+import { ProxyHosts } from './proxy-hosts';
+import { Certificates } from './certificates';
+import type {
+  NpmClientConfig,
+  NpmApiErrorBody,
+  TokenResponse,
+  AuthResponse,
+  RequestFn,
+} from './types';
+
+export class NpmApiError extends Error {
+  constructor(
+    public statusCode: number,
+    public body: NpmApiErrorBody | null,
+  ) {
+    const msg = body?.error?.message ?? `NPM API responded with ${statusCode}`;
+    super(msg);
+    this.name = 'NpmApiError';
+  }
+}
+
+export class NpmClient {
+  private baseUrl: string;
+  private token: string | null;
+  private tokenExpires: Date | null = null;
+  private email: string | null;
+  private password: string | null;
+
+  public readonly proxyHosts: ProxyHosts;
+  public readonly certificates: Certificates;
+
+  constructor(config: NpmClientConfig) {
+    const url = config.baseUrl.replace(/\/+$/, '');
+    try {
+      const parsed = new URL(url);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        throw new Error('baseUrl must use http or https protocol');
+      }
+      this.baseUrl = url;
+    } catch (err) {
+      throw new Error(`Invalid baseUrl: ${err instanceof Error ? err.message : 'Must be a valid URL'}`);
+    }
+
+    this.token = config.token ?? null;
+    this.email = config.email ?? null;
+    this.password = config.password ?? null;
+
+    const requestFn: RequestFn = this.request.bind(this);
+    this.proxyHosts = new ProxyHosts(requestFn);
+    this.certificates = new Certificates(requestFn);
+  }
+
+  async login(email?: string, password?: string): Promise<TokenResponse> {
+    const identity = email ?? this.email;
+    const secret = password ?? this.password;
+
+    if (!identity || !secret) {
+      throw new Error('Email and password are required for login.');
+    }
+
+    const res = await fetch(`${this.baseUrl}/api/tokens`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identity, secret }),
+    });
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => null) as NpmApiErrorBody | null;
+      throw new NpmApiError(res.status, body);
+    }
+
+    const data = await res.json() as AuthResponse;
+
+    if ('requires_2fa' in data) {
+      throw new Error(
+        '2FA is enabled on this NPM account. Pass a pre-authenticated token instead.',
+      );
+    }
+
+    this.token = data.token;
+    this.tokenExpires = new Date(data.expires);
+    this.email = identity;
+    this.password = secret;
+
+    return data;
+  }
+
+  async refreshToken(): Promise<TokenResponse> {
+    const data = await this.request<TokenResponse>('GET', '/api/tokens');
+    this.token = data.token;
+    this.tokenExpires = new Date(data.expires);
+    return data;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    options?: {
+      body?: unknown;
+      params?: Record<string, string>;
+      timeout?: number;
+    },
+  ): Promise<T> {
+    await this.ensureAuth();
+
+    let url = `${this.baseUrl}${path}`;
+
+    if (options?.params) {
+      const search = new URLSearchParams(options.params);
+      url += `?${search.toString()}`;
+    }
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (this.token) {
+      headers['Authorization'] = `Bearer ${this.token}`;
+    }
+
+    const timeoutMs = options?.timeout ?? 30_000;
+    const maxRetries = 2;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+      try {
+        const res = await fetch(url, {
+          method,
+          headers,
+          body: options?.body ? JSON.stringify(options.body) : undefined,
+          signal: controller.signal,
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => null) as NpmApiErrorBody | null;
+          throw new NpmApiError(res.status, body);
+        }
+
+        return await res.json() as T;
+      } catch (err) {
+        clearTimeout(timer);
+
+        if (err instanceof Error && err.name === 'AbortError') {
+          throw new Error(`Request timeout after ${timeoutMs}ms: ${method} ${path}`);
+        }
+
+        const isSocketError =
+          err instanceof TypeError &&
+          err.message === 'fetch failed' &&
+          (err.cause as NodeJS.ErrnoException)?.code === 'UND_ERR_SOCKET';
+
+        if (isSocketError && attempt < maxRetries) {
+          await new Promise((r) => setTimeout(r, 300 * (attempt + 1)));
+          continue;
+        }
+
+        throw err;
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    throw new Error('Request failed after retries.');
+  }
+
+  private async ensureAuth(): Promise<void> {
+    if (this.token && this.tokenExpires && this.tokenExpires > new Date()) {
+      return;
+    }
+
+    if (this.email && this.password) {
+      await this.login();
+      return;
+    }
+
+    if (!this.token) {
+      throw new Error(
+        'No authentication available. Provide a token or email+password.',
+      );
+    }
+  }
+
+  clearCredentials(): void {
+    this.token = null;
+    this.tokenExpires = null;
+    this.email = null;
+    this.password = null;
+  }
+}

--- a/packages/npm-sdk/src/index.ts
+++ b/packages/npm-sdk/src/index.ts
@@ -1,0 +1,23 @@
+export { NpmClient, NpmApiError } from './client';
+export { ProxyHosts } from './proxy-hosts';
+export { Certificates } from './certificates';
+
+export type {
+  NpmClientConfig,
+  TokenResponse,
+  TokenChallengeResponse,
+  AuthResponse,
+  ProxyHost,
+  ProxyHostLocation,
+  CreateProxyHostPayload,
+  UpdateProxyHostPayload,
+  Certificate,
+  CertificateMeta,
+  CreateLetsEncryptCertPayload,
+  CreateCustomCertPayload,
+  CreateCertificatePayload,
+  TestHttpResult,
+  Owner,
+  AccessList,
+  NpmApiErrorBody,
+} from './types';

--- a/packages/npm-sdk/src/proxy-hosts.ts
+++ b/packages/npm-sdk/src/proxy-hosts.ts
@@ -1,0 +1,82 @@
+import type {
+  RequestFn,
+  ProxyHost,
+  CreateProxyHostPayload,
+  UpdateProxyHostPayload,
+} from './types';
+import { validateAdvancedConfig, validateDomainNames } from './validation';
+
+export class ProxyHosts {
+  constructor(private request: RequestFn) {}
+
+  async list(options?: {
+    expand?: ('owner' | 'certificate' | 'access_list')[];
+    query?: string;
+  }): Promise<ProxyHost[]> {
+    const params: Record<string, string> = {};
+
+    if (options?.expand?.length) {
+      params.expand = options.expand.join(',');
+    }
+    if (options?.query) {
+      params.query = options.query;
+    }
+
+    return this.request<ProxyHost[]>('GET', '/api/nginx/proxy-hosts', { params });
+  }
+
+  async get(
+    id: number,
+    options?: { expand?: ('owner' | 'certificate' | 'access_list')[] },
+  ): Promise<ProxyHost> {
+    const params: Record<string, string> = {};
+
+    if (options?.expand?.length) {
+      params.expand = options.expand.join(',');
+    }
+
+    return this.request<ProxyHost>('GET', `/api/nginx/proxy-hosts/${id}`, { params });
+  }
+
+  async create(payload: CreateProxyHostPayload): Promise<ProxyHost> {
+    validateDomainNames(payload.domain_names);
+    validateAdvancedConfig(payload.advanced_config);
+
+    if (payload.locations) {
+      for (const location of payload.locations) {
+        validateAdvancedConfig(location.advanced_config);
+      }
+    }
+
+    return this.request<ProxyHost>('POST', '/api/nginx/proxy-hosts', {
+      body: payload,
+    });
+  }
+
+  async update(id: number, payload: UpdateProxyHostPayload): Promise<ProxyHost> {
+    validateDomainNames(payload.domain_names);
+    validateAdvancedConfig(payload.advanced_config);
+
+    if (payload.locations) {
+      for (const location of payload.locations) {
+        validateAdvancedConfig(location.advanced_config);
+      }
+    }
+
+    return this.request<ProxyHost>('PUT', `/api/nginx/proxy-hosts/${id}`, {
+      body: payload,
+    });
+  }
+
+  async delete(id: number): Promise<boolean> {
+    return this.request<boolean>('DELETE', `/api/nginx/proxy-hosts/${id}`);
+  }
+
+  async enable(id: number): Promise<boolean> {
+    return this.request<boolean>('POST', `/api/nginx/proxy-hosts/${id}/enable`);
+  }
+
+  async disable(id: number): Promise<boolean> {
+    return this.request<boolean>('POST', `/api/nginx/proxy-hosts/${id}/disable`);
+  }
+}

--- a/packages/npm-sdk/src/types.ts
+++ b/packages/npm-sdk/src/types.ts
@@ -1,0 +1,186 @@
+/**
+ * SDK configuration. Pass either a token or email+password for authentication.
+ * If both are provided, the token is used first. Credentials are used as fallback
+ * and for automatic re-authentication when the token expires.
+ */
+export interface NpmClientConfig {
+  baseUrl: string;
+  token?: string;
+  email?: string;
+  password?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+export interface TokenResponse {
+  token: string;
+  expires: string;
+}
+
+export interface TokenChallengeResponse {
+  requires_2fa: true;
+  challenge_token: string;
+}
+
+export type AuthResponse = TokenResponse | TokenChallengeResponse;
+
+// ---------------------------------------------------------------------------
+// Proxy Hosts
+// ---------------------------------------------------------------------------
+
+export interface ProxyHostLocation {
+  path: string;
+  forward_scheme: 'http' | 'https';
+  forward_host: string;
+  forward_port: number;
+  forward_path?: string;
+  advanced_config?: string;
+}
+
+export interface CreateProxyHostPayload {
+  domain_names: string[];
+  forward_scheme: 'http' | 'https';
+  forward_host: string;
+  forward_port: number;
+  certificate_id?: number | 'new';
+  ssl_forced?: boolean;
+  hsts_enabled?: boolean;
+  hsts_subdomains?: boolean;
+  trust_forwarded_proto?: boolean;
+  http2_support?: boolean;
+  block_exploits?: boolean;
+  caching_enabled?: boolean;
+  allow_websocket_upgrade?: boolean;
+  access_list_id?: number;
+  advanced_config?: string;
+  enabled?: boolean;
+  meta?: Record<string, unknown>;
+  locations?: ProxyHostLocation[];
+}
+
+export interface UpdateProxyHostPayload extends Partial<CreateProxyHostPayload> {}
+
+export interface ProxyHost {
+  id: number;
+  created_on: string;
+  modified_on: string;
+  owner_user_id: number;
+  domain_names: string[];
+  forward_scheme: 'http' | 'https';
+  forward_host: string;
+  forward_port: number;
+  certificate_id: number;
+  ssl_forced: boolean;
+  hsts_enabled: boolean;
+  hsts_subdomains: boolean;
+  trust_forwarded_proto: boolean;
+  http2_support: boolean;
+  block_exploits: boolean;
+  caching_enabled: boolean;
+  allow_websocket_upgrade: boolean;
+  access_list_id: number;
+  advanced_config: string;
+  enabled: boolean;
+  meta: Record<string, unknown>;
+  locations: ProxyHostLocation[];
+  owner?: Owner;
+  certificate?: Certificate;
+  access_list?: AccessList;
+}
+
+// ---------------------------------------------------------------------------
+// Certificates
+// ---------------------------------------------------------------------------
+
+export interface CertificateMeta {
+  dns_challenge?: boolean;
+  dns_provider?: string;
+  dns_provider_credentials?: string;
+  propagation_seconds?: number;
+  key_type?: 'rsa' | 'ecdsa';
+  [key: string]: unknown;
+}
+
+export interface CreateLetsEncryptCertPayload {
+  provider: 'letsencrypt';
+  domain_names: string[];
+  meta?: CertificateMeta;
+}
+
+export interface CreateCustomCertPayload {
+  provider: 'other';
+  nice_name: string;
+}
+
+export type CreateCertificatePayload =
+  | CreateLetsEncryptCertPayload
+  | CreateCustomCertPayload;
+
+export interface Certificate {
+  id: number;
+  created_on: string;
+  modified_on: string;
+  owner_user_id: number;
+  provider: string;
+  nice_name: string;
+  domain_names: string[];
+  expires_on: string;
+  meta: CertificateMeta;
+  owner?: Owner;
+}
+
+export interface TestHttpResult {
+  [domain: string]: 'ok' | 'no-host' | 'failed' | '404' | 'wrong-data' | string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared / Expansion types
+// ---------------------------------------------------------------------------
+
+export interface Owner {
+  id: number;
+  created_on: string;
+  modified_on: string;
+  is_disabled: boolean;
+  email: string;
+  name: string;
+  nickname: string;
+  avatar: string;
+  roles: string[];
+}
+
+export interface AccessList {
+  id: number;
+  created_on: string;
+  modified_on: string;
+  owner_user_id: number;
+  name: string;
+  meta: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// API Error
+// ---------------------------------------------------------------------------
+
+export interface NpmApiErrorBody {
+  error: {
+    code: number;
+    message: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: shared request function signature
+// ---------------------------------------------------------------------------
+
+export type RequestFn = <T>(
+  method: string,
+  path: string,
+  options?: {
+    body?: unknown;
+    params?: Record<string, string>;
+    timeout?: number;
+  },
+) => Promise<T>;

--- a/packages/npm-sdk/src/types.ts
+++ b/packages/npm-sdk/src/types.ts
@@ -60,7 +60,7 @@ export interface CreateProxyHostPayload {
   locations?: ProxyHostLocation[];
 }
 
-export interface UpdateProxyHostPayload extends Partial<CreateProxyHostPayload> {}
+export type UpdateProxyHostPayload = Partial<CreateProxyHostPayload>;
 
 export interface ProxyHost {
   id: number;
@@ -132,7 +132,7 @@ export interface Certificate {
 }
 
 export interface TestHttpResult {
-  [domain: string]: 'ok' | 'no-host' | 'failed' | '404' | 'wrong-data' | string;
+  [domain: string]: 'ok' | 'no-host' | 'failed' | '404' | 'wrong-data' | (string & {});
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/npm-sdk/src/validation.ts
+++ b/packages/npm-sdk/src/validation.ts
@@ -53,5 +53,22 @@ export function validateDomainNames(domains: string[] | undefined): void {
     if (domain.length > 253) {
       throw new Error(`Domain name too long: "${domain}" (max 253 characters)`);
     }
+
+    if (domain.startsWith('.') || domain.endsWith('.')) {
+      throw new Error(`Invalid domain name: "${domain}" must not start or end with a dot`);
+    }
+
+    if (domain.includes('..')) {
+      throw new Error(`Invalid domain name: "${domain}" must not contain consecutive dots`);
+    }
+
+    for (const label of domain.split('.')) {
+      if (label.length === 0) {
+        throw new Error(`Invalid domain name: "${domain}" contains an empty label`);
+      }
+      if (label.length > 63) {
+        throw new Error(`Invalid domain name: "${domain}" label "${label}" exceeds 63 characters`);
+      }
+    }
   }
 }

--- a/packages/npm-sdk/src/validation.ts
+++ b/packages/npm-sdk/src/validation.ts
@@ -1,0 +1,57 @@
+/**
+ * Validation utilities to prevent accidental nginx configuration breaks
+ * and injection attacks when user input is passed through the SDK.
+ */
+
+/**
+ * Validates advanced_config to prevent patterns that would break nginx configuration.
+ * This provides basic protection against common mistakes and injection attacks.
+ */
+export function validateAdvancedConfig(config: string | undefined): void {
+  if (!config || config.trim() === '') {
+    return;
+  }
+
+  const breakoutPatterns = [
+    { pattern: /}\s*server\s*{/i, message: 'Closing and opening server blocks would break NPM configuration' },
+    { pattern: /}\s*http\s*{/i, message: 'Closing and opening http blocks would break NPM configuration' },
+  ];
+
+  for (const { pattern, message } of breakoutPatterns) {
+    if (pattern.test(config)) {
+      throw new Error(`Invalid advanced_config: ${message}`);
+    }
+  }
+}
+
+/**
+ * Validates domain names to prevent characters that would break nginx configuration.
+ *
+ * Supports:
+ * - Standard domains: example.com, sub.example.com
+ * - Wildcards: *.example.com
+ * - Single-label: localhost, myserver
+ * - IP addresses: 192.168.1.1
+ * - Unicode/IDN domains (if already in ASCII/punycode form)
+ */
+export function validateDomainNames(domains: string[] | undefined): void {
+  if (!domains || domains.length === 0) {
+    return;
+  }
+
+  for (const domain of domains) {
+    if (!domain || domain.trim() === '') {
+      throw new Error('Domain name cannot be empty');
+    }
+
+    if (/[\s;{}]/.test(domain)) {
+      throw new Error(
+        `Invalid domain name: "${domain}" contains characters that would break nginx configuration (spaces, semicolons, or braces)`
+      );
+    }
+
+    if (domain.length > 253) {
+      throw new Error(`Domain name too long: "${domain}" (max 253 characters)`);
+    }
+  }
+}

--- a/packages/npm-sdk/tsconfig.json
+++ b/packages/npm-sdk/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
     dependencies:
       '@better-auth/sso':
         specifier: 1.5.4
-        version: 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(better-call@1.3.2(zod@4.3.6))
+        version: 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(better-call@1.3.2(zod@4.3.6))
       '@fazri/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -41,7 +41,7 @@ importers:
         version: 2.4.3
       better-auth:
         specifier: 1.5.4
-        version: 1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       cors:
         specifier: ^2.8.5
         version: 2.8.6
@@ -78,7 +78,7 @@ importers:
     dependencies:
       '@better-auth/sso':
         specifier: 1.5.4
-        version: 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(better-call@1.3.2(zod@4.3.6))
+        version: 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(better-call@1.3.2(zod@4.3.6))
       '@heroui/react':
         specifier: ^2.8.5
         version: 2.8.5(@types/react@19.2.14)(framer-motion@12.23.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.16)
@@ -126,7 +126,7 @@ importers:
         version: 4.7.0(react@19.2.4)
       '@sentry/nextjs':
         specifier: ^10.45.0
-        version: 10.45.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
+        version: 10.45.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
       '@tabler/icons-react':
         specifier: ^3.35.0
         version: 3.35.0(react@19.2.4)
@@ -144,7 +144,7 @@ importers:
         version: 1.15.0
       better-auth:
         specifier: 1.5.4
-        version: 1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -173,8 +173,8 @@ importers:
         specifier: ^12.23.22
         version: 12.23.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next:
-        specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 16.2.4
+        version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -231,8 +231,8 @@ importers:
         specifier: ^9
         version: 9.36.0(jiti@2.6.1)
       eslint-config-next:
-        specifier: 16.2.1
-        version: 16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 16.2.4
+        version: 16.2.4(@typescript-eslint/parser@8.57.2(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.1.16
@@ -1429,60 +1429,60 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@16.2.3':
-    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
+  '@next/env@16.2.4':
+    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
-  '@next/eslint-plugin-next@16.2.1':
-    resolution: {integrity: sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==}
+  '@next/eslint-plugin-next@16.2.4':
+    resolution: {integrity: sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==}
 
-  '@next/swc-darwin-arm64@16.2.3':
-    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
+  '@next/swc-darwin-arm64@16.2.4':
+    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.3':
-    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
+  '@next/swc-darwin-x64@16.2.4':
+    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.3':
-    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
+  '@next/swc-linux-arm64-gnu@16.2.4':
+    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.3':
-    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
+  '@next/swc-linux-arm64-musl@16.2.4':
+    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.3':
-    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
+  '@next/swc-linux-x64-gnu@16.2.4':
+    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.3':
-    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
+  '@next/swc-linux-x64-musl@16.2.4':
+    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.3':
-    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
+  '@next/swc-win32-arm64-msvc@16.2.4':
+    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.3':
-    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
+  '@next/swc-win32-x64-msvc@16.2.4':
+    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -4511,8 +4511,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@16.2.1:
-    resolution: {integrity: sha512-qhabwjQZ1Mk53XzXvmogf8KQ0tG0CQXF0CZ56+2/lVhmObgmaqj7x5A1DSrWdZd3kwI7GTPGUjFne+krRxYmFg==}
+  eslint-config-next@16.2.4:
+    resolution: {integrity: sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -5432,8 +5432,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.3:
-    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
+  next@16.2.4:
+    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -6619,12 +6619,12 @@ snapshots:
       '@prisma/client': 6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3)
       prisma: 6.16.3(typescript@5.9.3)
 
-  '@better-auth/sso@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(better-call@1.3.2(zod@4.3.6))':
+  '@better-auth/sso@1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(better-call@1.3.2(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      better-auth: 1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       better-call: 1.3.2(zod@4.3.6)
       fast-xml-parser: 5.7.1
       jose: 6.2.2
@@ -8027,34 +8027,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.2.3': {}
+  '@next/env@16.2.4': {}
 
-  '@next/eslint-plugin-next@16.2.1':
+  '@next/eslint-plugin-next@16.2.4':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.3':
+  '@next/swc-darwin-arm64@16.2.4':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.3':
+  '@next/swc-darwin-x64@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.3':
+  '@next/swc-linux-arm64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.3':
+  '@next/swc-linux-arm64-musl@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.3':
+  '@next/swc-linux-x64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.3':
+  '@next/swc-linux-x64-musl@16.2.4':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.3':
+  '@next/swc-win32-arm64-msvc@16.2.4':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.3':
+  '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
 
   '@noble/ciphers@2.1.1': {}
@@ -10117,7 +10117,7 @@ snapshots:
 
   '@sentry/core@8.55.1': {}
 
-  '@sentry/nextjs@10.45.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4)':
+  '@sentry/nextjs@10.45.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -10130,7 +10130,7 @@ snapshots:
       '@sentry/react': 10.45.0(react@19.2.4)
       '@sentry/vercel-edge': 10.45.0
       '@sentry/webpack-plugin': 5.1.1(webpack@5.105.4)
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.60.0
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -10978,7 +10978,7 @@ snapshots:
 
   bcryptjs@2.4.3: {}
 
-  better-auth@1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  better-auth@1.5.4(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))(mongodb@7.2.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@better-auth/core': 1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3)))
@@ -11001,7 +11001,7 @@ snapshots:
       '@prisma/client': 6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3)
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.15.6)(kysely@0.28.14)(pg@8.20.0)(prisma@6.16.3(typescript@5.9.3))
       mongodb: 7.2.0
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       pg: 8.20.0
       prisma: 6.16.3(typescript@5.9.3)
       react: 19.2.4
@@ -11501,9 +11501,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.2.4(@typescript-eslint/parser@8.57.2(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.2.1
+      '@next/eslint-plugin-next': 16.2.4
       eslint: 9.36.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.36.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.1)))(eslint@9.36.0(jiti@2.6.1))
@@ -12456,9 +12456,9 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 16.2.3
+      '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.10
       caniuse-lite: 1.0.30001780
@@ -12467,14 +12467,14 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.3
-      '@next/swc-darwin-x64': 16.2.3
-      '@next/swc-linux-arm64-gnu': 16.2.3
-      '@next/swc-linux-arm64-musl': 16.2.3
-      '@next/swc-linux-x64-gnu': 16.2.3
-      '@next/swc-linux-x64-musl': 16.2.3
-      '@next/swc-win32-arm64-msvc': 16.2.3
-      '@next/swc-win32-x64-msvc': 16.2.3
+      '@next/swc-darwin-arm64': 16.2.4
+      '@next/swc-darwin-x64': 16.2.4
+      '@next/swc-linux-arm64-gnu': 16.2.4
+      '@next/swc-linux-arm64-musl': 16.2.4
+      '@next/swc-linux-x64-gnu': 16.2.4
+      '@next/swc-linux-x64-musl': 16.2.4
+      '@next/swc-win32-arm64-msvc': 16.2.4
+      '@next/swc-win32-x64-msvc': 16.2.4
       '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@fazri/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@fazri/npm-sdk':
+        specifier: workspace:*
+        version: link:../../packages/npm-sdk
       '@sentry/node':
         specifier: ^8
         version: 8.55.1
@@ -254,6 +257,15 @@ importers:
       prisma:
         specifier: ^6.0.0
         version: 6.16.3(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/npm-sdk:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
       typescript:
         specifier: ^5.7.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

- **`@fazri/npm-sdk`** — internal workspace package wrapping the Nginx Proxy Manager API (proxy hosts, Let's Encrypt certificates)
- **Custom domain flow** — TXT ownership verification → A record DNS check → NPM proxy host + Let's Encrypt SSL provisioning with tracked async status (`provisioning` → `active` / `failed`)
- **Vercel-style UI** — live DNS check, SSL status badge, provisioning spinner, retry button, LE rate-limit detection
- **SUPER_ADMIN system settings** — `/admin/system` page to update `FRONTEND_HOST`/`FRONTEND_PORT` in DB and bulk-sync all existing NPM proxy hosts in one click
- **Jenkins + Dockerfile** — NPM/domain env vars wired into auth container; `@fazri/npm-sdk` dist explicitly copied into `pnpm deploy` output

## Edge case checklist

### DNS & activation
- [x] Domain activated without A record → 422, DNS not-found error shown
- [x] A record points to wrong IP → 422, resolved IP vs expected IP shown
- [x] Domain behind Cloudflare orange cloud → blocked at both `check-dns` and `activate` with explicit proxy warning
- [x] Concurrent activate requests for the same domain → atomic `updateMany` ensures only one proceeds
- [ ] `FAZRI_SERVER_IP` not set but `NPM_API_URL` is → 500 with config error, not silent bypass

### SSL provisioning
- [x] NPM `testHttp` pre-flight fails → descriptive error mapped from raw NPM codes (`404`, `no-host`, `failed`, `wrong-data`, `other:*`)
- [x] Auth service crashes mid-provisioning → stuck `provisioning` records auto-healed to `failed` after 20 min on next list fetch
- [x] SSL provisioning fails → `sslStatus = failed`, error stored, retry button shown to org admin
- [x] Retry when Let's Encrypt rate-limited (5 certs/domain/week) → 429 with specific message, retry blocked
- [x] Legacy `verified = true` records with `sslStatus = null` → treated as active, no migration needed

### Deprovision
- [x] Domain deleted → NPM proxy host deleted by stored `npmProxyHostId` (avoids targeting a freshly re-registered domain for the same name)
- [x] Domain deleted when `npmProxyHostId` is null → falls back to domain-name scan in NPM
- [x] NPM proxy host already gone at delete time → 404 swallowed, no crash

### System settings sync
- [x] Existing proxy hosts provisioned before `npmProxyHostId` column existed → sync finds them by domain-name lookup against live NPM list
- [x] `npmProxyHostId` missing in DB but host exists in NPM → backfilled after successful sync
- [x] One host fails to sync → others still update, failed list returned in response, shown in UI
- [x] `NPM_API_URL` not configured → sync returns 422 immediately

### Auth & access
- [x] Non-owner/admin org member tries to activate/delete → 403
- [x] Non-SUPER_ADMIN calls `/api/system/npm-config` → 403
- [x] Custom domain resolution for unverified domain → 404 from `/api/org/resolve`

### DNS resolver
- [x] All DNS lookups use `1.1.1.1` / `1.0.0.1` — not the host's default resolver — to avoid split-horizon or ISP caching issues

## Test plan

- [x] Register domain → verify TXT record → check DNS resolves to server IP → activate → confirm NPM proxy host created with correct `forward_host`/`forward_port`
- [x] Open `/admin/system`, change host/port, click Apply → confirm NPM proxy hosts updated, synced count matches active domain count
- [x] Delete a domain → confirm NPM proxy host is removed
- [x] Retry SSL on a failed domain → confirm `sslStatus` transitions back to `provisioning` then `active`
- [x] Deploy auth container → confirm `@fazri/npm-sdk` resolves without `MODULE_NOT_FOUND`

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Organizations can now register, verify, and activate custom domains with automatic SSL certificate provisioning
- Multi-tenant domain routing enables organization resolution by hostname
- New admin system configuration interface for managing proxy settings
- Settings navigation expanded with Custom Domain and Single Sign-On options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->